### PR TITLE
fix(ci): disable Husky hooks in release workflow

### DIFF
--- a/.changeset/fix-release-workflow.md
+++ b/.changeset/fix-release-workflow.md
@@ -1,0 +1,5 @@
+---
+"@protomolecule/eslint-config": patch
+---
+
+Fix release workflow by disabling Husky hooks in CI to prevent prettier errors during changeset commits

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          HUSKY: 0 # Disable Husky hooks in CI
 
       - name: ✨ Enhance GitHub Release Notes
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary
- Fixes the release workflow failing with "prettier ENOENT" error
- Disables Husky git hooks in CI environment to prevent pre-commit hook failures

## Problem
The release workflow was failing when changesets tried to commit version updates because:
1. The pre-commit hook runs prettier
2. Prettier binary wasn't available in PATH during git operations in CI
3. This caused "spawn prettier ENOENT" error

## Solution
Added `HUSKY: 0` environment variable to the changesets step which disables Husky hooks in CI. This is a common best practice for CI workflows.

## Related Issue
Fixes #82

## Test Plan
- [x] Changeset included
- [ ] Will verify release workflow succeeds after merge