### PR TITLE
fix: add NPM auth via .npmrc with enhanced safeguards (Option 1)

### DIFF
--- a/.changeset/fix-npm-auth-option1.md
+++ b/.changeset/fix-npm-auth-option1.md
@@ -1,0 +1,14 @@
+---
+"@protomolecule/eslint-config": patch
+---
+
+Fix NPM authentication with explicit .npmrc and enhanced safeguards (Option 1)
+
+- Added explicit .npmrc file creation with NPM_TOKEN before publishing
+- Added npm whoami verification to ensure auth is working
+- Enhanced with important safeguards:
+  - Concurrency control (queues releases instead of cancelling)
+  - Pre-publish validation and changeset status checking
+  - Enhanced release summaries with clear success/failure indicators
+  - Better error messages with actionable next steps
+- Maintains all existing custom logic and control

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency: 
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false  # Queue releases instead of cancelling
 
 jobs:
   release:
@@ -70,6 +70,29 @@ jobs:
           
           echo "✅ Build verification passed"
 
+      - name: 📋 Pre-publish Validation
+        run: |
+          echo "## 📋 Pre-publish Validation" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          # Check changeset status verbosely
+          echo "### Changeset Status" >> $GITHUB_STEP_SUMMARY
+          pnpm changeset status --verbose >> $GITHUB_STEP_SUMMARY 2>&1 || {
+            echo "⚠️ Note: Some packages may have unreleased changes" >> $GITHUB_STEP_SUMMARY
+          }
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Package Build Validation" >> $GITHUB_STEP_SUMMARY
+          
+          # Verify critical files exist for publishable packages
+          if [ -f "packages/eslint-config/dist/index.js" ]; then
+            echo "✅ ESLint config build output verified" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⚠️ ESLint config build output not found at expected location" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
+
       - name: 📋 Check for changesets
         id: changesets-check
         run: |
@@ -92,6 +115,21 @@ jobs:
           # Configure git for commits
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: 🔐 Setup NPM Authentication
+        if: steps.changesets-check.outputs.has_changesets == 'true'
+        run: |
+          # Create .npmrc with auth token for publishing
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+          
+          # Verify authentication is working
+          npm whoami --registry https://registry.npmjs.org || {
+            echo "❌ NPM authentication failed. Please check NPM_TOKEN secret."
+            exit 1
+          }
+          echo "✅ NPM authentication configured successfully"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: 🚀 Version and Publish to NPM
         if: steps.changesets-check.outputs.has_changesets == 'true'
@@ -228,19 +266,36 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 📊 Generate Summary
+      - name: 📊 Generate Release Summary
         if: always()
         run: |
-          echo "## 🚀 Continuous Release Summary" >> $GITHUB_STEP_SUMMARY
+          echo "## 🚀 Release Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           if [ "${{ steps.changesets-check.outputs.has_changesets }}" == "true" ]; then
             if [ "${{ steps.publish.outputs.publish_success }}" == "true" ]; then
-              echo "✅ Changesets processed and packages published successfully" >> $GITHUB_STEP_SUMMARY
-            else
-              echo "⚠️ Changesets processed but NPM publishing failed" >> $GITHUB_STEP_SUMMARY
+              echo "### ✅ Release Successful!" >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY
-              echo "**Action Required:** Check NPM_TOKEN and package configuration" >> $GITHUB_STEP_SUMMARY
+              echo "Packages have been published to NPM successfully." >> $GITHUB_STEP_SUMMARY
+              
+              if [ -f publish-output.txt ]; then
+                echo "" >> $GITHUB_STEP_SUMMARY
+                echo "**Published Packages:**" >> $GITHUB_STEP_SUMMARY
+                # Extract package info from output
+                grep -E "@[a-z0-9-]+/[a-z0-9-]+@[0-9]+\.[0-9]+\.[0-9]+" publish-output.txt | while read -r pkg; do
+                  echo "- $pkg" >> $GITHUB_STEP_SUMMARY
+                done || echo "See publishing output below for details." >> $GITHUB_STEP_SUMMARY
+              fi
+            else
+              echo "### ⚠️ Release Failed" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "Changesets were found but publishing failed." >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**Action Required:**" >> $GITHUB_STEP_SUMMARY
+              echo "1. Check the workflow logs for detailed error messages" >> $GITHUB_STEP_SUMMARY
+              echo "2. Verify NPM_TOKEN is correctly configured" >> $GITHUB_STEP_SUMMARY
+              echo "3. Ensure package.json files are valid" >> $GITHUB_STEP_SUMMARY
+              echo "4. Check if the .npmrc authentication step succeeded" >> $GITHUB_STEP_SUMMARY
             fi
             
             if [ -f publish-output.txt ]; then
@@ -251,9 +306,13 @@ jobs:
               echo '```' >> $GITHUB_STEP_SUMMARY
             fi
           else
-            echo "No changesets found - no release needed" >> $GITHUB_STEP_SUMMARY
+            echo "### ℹ️ No Release Needed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "No changesets found in this push to main." >> $GITHUB_STEP_SUMMARY
+            echo "All packages are up to date." >> $GITHUB_STEP_SUMMARY
           fi
           
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "---" >> $GITHUB_STEP_SUMMARY
-          echo "_Workflow triggered by: ${{ github.actor }}_" >> $GITHUB_STEP_SUMMARY
+          echo "_Release triggered by commit: \`${{ github.sha }}\`_" >> $GITHUB_STEP_SUMMARY
+          echo "_Workflow triggered by: @${{ github.actor }}_" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

This PR fixes the NPM authentication issue using explicit .npmrc configuration (Option 1).

## Problem

The release workflow fails with `ENEEDAUTH` errors:
```
error npm error code ENEEDAUTH
error npm error need auth This command requires you to be logged in to https://registry.npmjs.org
```

## Solution: Explicit .npmrc Configuration

Creates `.npmrc` file with auth token before publishing:
- ✅ Direct control over authentication
- ✅ npm whoami verification ensures auth works
- ✅ Clear debugging visibility
- ✅ Works with existing workflow logic

## Enhanced with Critical Safeguards

Added the same enhancements as Option 4 for fair comparison:

### 1. Concurrency Control
```yaml
concurrency: 
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: false  # Queue releases instead of cancelling
```

### 2. Pre-publish Validation
- Changeset status checking
- Build output verification  
- Clear status reporting

### 3. Enhanced Release Summaries
- Success/failure indicators
- Actionable error messages
- Better package details formatting

## Comparison with Option 4 (#93)

| Feature | Option 1 (This PR) | Option 4 (#93) |
|---------|-------------------|----------------|
| **Lines added** | +73 | +46 |
| **Lines removed** | -8 | -160 |
| **Net change** | +65 lines | -114 lines |
| **NPM auth method** | Explicit .npmrc | Automatic via action |
| **GitHub releases** | Custom logic | Automatic with changelogs |
| **Concurrency** | ✅ Queue releases | ✅ Queue releases |
| **Pre-publish validation** | ✅ Full validation | ✅ Full validation |
| **Custom control** | ✅ Full control | ❌ Less control |
| **Maintenance** | You maintain | Changesets team |
| **Rollback logic** | ✅ Explicit | ✅ Built-in |
| **Push retry logic** | ✅ 3 attempts | ❌ Single attempt |

## Key Differences

**Option 1 advantages:**
- Full control over every step
- Explicit rollback messages
- Push retry logic (3 attempts)
- Can customize any part

**Option 4 advantages:**
- 179 fewer lines of code
- Automatic GitHub releases with changelogs
- Community maintained
- Simpler configuration

## Testing

The workflow will:
1. Check and validate changesets
2. Build and verify packages
3. Create .npmrc with NPM_TOKEN
4. Verify auth with npm whoami
5. Publish with rollback on failure
6. Create GitHub releases
7. Generate detailed summaries

Fixes #92