### PR TITLE
fix: remove root package from changeset to fix workflow failure

### DIFF
--- a/.changeset/add-markdown-linting.md
+++ b/.changeset/add-markdown-linting.md
@@ -1,5 +1,4 @@
 ---
-"protomolecule": minor
 "@protomolecule/ui": patch
 "@protomolecule/eslint-config": patch
 "@protomolecule/tsconfig": patch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,9 @@ When creating PRs that modify any package:
 
 5. **CI will block PRs without changesets** - this is mandatory
 
-**Note:** Only `@protomolecule/eslint-config` is published to NPM. Other packages (`ui`, `tsconfig`, `radix-colors`, `github-rulesets`) are private but still require changesets for version tracking.
+**IMPORTANT:** Never include the root package name (e.g., `"protomolecule"`) in changesets. Only include scoped package names that start with `@protomolecule/`. The root package in a monorepo is not versioned or published.
+
+**Note:** Only `@protomolecule/eslint-config` is published to NPM. Other packages (`ui`, `tsconfig`, `colours`, `github-rulesets`) are private but still require changesets for version tracking.
 
 ## Monorepo Structure
 


### PR DESCRIPTION
## Summary

This PR fixes the workflow failure that occurred after merging PR #105 by removing an invalid root package reference from the changeset file.

## Problem

The changeset file included `"protomolecule": minor` which caused the release workflow to fail with:
```
Error: Found changeset add-markdown-linting for package protomolecule which is not in the workspace  
```

## Solution

1. Removed the invalid root package reference from `.changeset/add-markdown-linting.md`
2. Updated `CLAUDE.md` documentation to clarify that changesets should never include the root package name

## Key Changes

- 🔧 Fixed `.changeset/add-markdown-linting.md` by removing `"protomolecule": minor` line
- 📝 Added clear warning in `CLAUDE.md` about not including root package in changesets
- ✅ This will allow the release workflow to run successfully

## Context

In a monorepo setup, only the individual packages (those with `@protomolecule/` prefix) should be versioned and potentially published. The root package itself is just a container for the workspace and should not be included in changesets.

Fixes the workflow failure from: https://github.com/RobEasthope/protomolecule/actions/runs/17645288960