### PR TITLE
fix: update changeset to use renamed package name

### DIFF
--- a/.changeset/add-markdown-linting.md
+++ b/.changeset/add-markdown-linting.md
@@ -2,7 +2,7 @@
 "@protomolecule/ui": patch
 "@protomolecule/eslint-config": patch
 "@protomolecule/tsconfig": patch
-"@protomolecule/radix-colors": patch
+"@protomolecule/colours": patch
 "@protomolecule/github-rulesets": patch
 ---
 


### PR DESCRIPTION
## 🚨 Critical Fix for Release Workflow

This PR fixes the release workflow failure that's blocking all NPM publishing.

## Problem

The changeset file `.changeset/add-markdown-linting.md` was still referencing the old package name `@protomolecule/radix-colors` instead of the renamed package `@protomolecule/colours`.

This caused the release workflow to fail with:
```
Error: Found changeset add-markdown-linting for package @protomolecule/radix-colors which is not in the workspace
```

## Solution

Updated the changeset file to use the correct package name: `@protomolecule/colours`

## Impact

- ✅ Fixes the release workflow blocking all NPM publishing
- ✅ Allows changesets to properly version packages
- ✅ Unblocks CI/CD pipeline

## Testing

Once merged, the release workflow should run successfully and apply the pending changesets.

## Related

- Fixes #110 
- Failed workflow run: https://github.com/RobEasthope/protomolecule/actions/runs/17645780980
- Original rename PR: #104

## Priority

**🔴 HIGH PRIORITY** - This is blocking all releases. Please review and merge ASAP.