### PR TITLE
fix(ci): build eslint-config before typecheck

### DIFF
--- a/.github/workflows/linting-and-testing.yml
+++ b/.github/workflows/linting-and-testing.yml
@@ -87,6 +87,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-tsbuildinfo-
 
+      - name: 🏗️ Build eslint-config package
+        run: pnpm --filter @protomolecule/eslint-config build
+
       - name: 🔎 Run TypeScript Check
         id: typecheck
         run: |


### PR DESCRIPTION
## Summary

Fixes the typecheck CI job failure by adding a build step for `@protomolecule/eslint-config` before running TypeScript checks.

## Problem

The typecheck job was failing with:
```
Error: eslint.config.ts(1,27): error TS2307: Cannot find module '@protomolecule/eslint-config' or its corresponding type declarations.
```

## Root Cause

- The lint job correctly builds `@protomolecule/eslint-config` before linting
- The typecheck job did NOT build it before running `pnpm run typecheck`
- Root's `eslint.config.ts` imports `@protomolecule/eslint-config`
- TypeScript couldn't find the types because `dist/` folder didn't exist

## Solution

Added explicit build step for `@protomolecule/eslint-config` in the typecheck job, matching the pattern used in the lint job:

```yaml
- name: 🏗️ Build eslint-config package
  run: pnpm --filter @protomolecule/eslint-config build
```

## Changes

- ✅ Added build step in typecheck job (line 90-91)
- ✅ Workflow YAML validated with `pnpm lint:workflows`
- ✅ No changeset needed (CI-only change, no package modifications)

## Testing

The CI will now:
1. Build `@protomolecule/eslint-config` 
2. Run `pnpm run build` (builds remaining packages)
3. Run `pnpm run typecheck` (now has types available)

This matches the working pattern from the lint job.

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)