### PR TITLE
feat: add package metadata fields for npm discoverability

### DIFF
--- a/.changeset/add-package-metadata.md
+++ b/.changeset/add-package-metadata.md
@@ -1,0 +1,7 @@
+---
+"@protomolecule/ui": patch
+"@protomolecule/eslint-config": patch
+"@protomolecule/colours": patch
+---
+
+Add package metadata fields for improved npm discoverability. Added keywords, author, homepage, and bugs fields to all published packages to improve search ranking and provide clear support channels.

--- a/packages/colours/package.json
+++ b/packages/colours/package.json
@@ -2,12 +2,28 @@
   "name": "@protomolecule/colours",
   "version": "2.1.8",
   "description": "Radix colors CSS imports for Protomolecule projects",
+  "keywords": [
+    "colors",
+    "colours",
+    "radix-ui",
+    "design-tokens",
+    "css",
+    "theme"
+  ],
+  "homepage": "https://github.com/RobEasthope/protomolecule#readme",
+  "bugs": {
+    "url": "https://github.com/RobEasthope/protomolecule/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/RobEasthope/protomolecule.git",
     "directory": "packages/colours"
   },
   "license": "MIT",
+  "author": {
+    "name": "Rob Easthope",
+    "url": "https://github.com/RobEasthope"
+  },
   "main": "index.css",
   "files": [
     "index.css"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -2,12 +2,28 @@
   "name": "@protomolecule/eslint-config",
   "version": "2.1.7",
   "description": "Shared ESLint configuration for Protomolecule projects",
+  "keywords": [
+    "eslint",
+    "eslint-config",
+    "linting",
+    "typescript",
+    "astro",
+    "code-quality"
+  ],
+  "homepage": "https://github.com/RobEasthope/protomolecule#readme",
+  "bugs": {
+    "url": "https://github.com/RobEasthope/protomolecule/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/RobEasthope/protomolecule.git",
     "directory": "packages/eslint-config"
   },
   "license": "MIT",
+  "author": {
+    "name": "Rob Easthope",
+    "url": "https://github.com/RobEasthope"
+  },
   "type": "module",
   "exports": {
     ".": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,12 +2,32 @@
   "name": "@protomolecule/ui",
   "version": "3.1.1",
   "description": "React component library for Protomolecule projects",
+  "keywords": [
+    "react",
+    "components",
+    "ui",
+    "tailwind",
+    "tailwindcss",
+    "storybook",
+    "component-library",
+    "typescript",
+    "sanity",
+    "portable-text"
+  ],
+  "homepage": "https://github.com/RobEasthope/protomolecule#readme",
+  "bugs": {
+    "url": "https://github.com/RobEasthope/protomolecule/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/RobEasthope/protomolecule.git",
     "directory": "packages/ui"
   },
   "license": "MIT",
+  "author": {
+    "name": "Rob Easthope",
+    "url": "https://github.com/RobEasthope"
+  },
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

Adds important package metadata fields to all published packages to improve npm discoverability and provide clear support channels.

## Changes

Added the following fields to all 3 published packages:

### ✅ Added Fields

1. **keywords** - Improves npm search ranking
   - `@protomolecule/ui`: `react`, `components`, `ui`, `tailwind`, `storybook`, `typescript`, `sanity`, etc.
   - `@protomolecule/eslint-config`: `eslint`, `linting`, `typescript`, `astro`, `code-quality`
   - `@protomolecule/colours`: `colors`, `radix-ui`, `design-tokens`, `css`, `theme`

2. **author** - Shows package ownership
   ```json
   "author": {
     "name": "Rob Easthope",
     "url": "https://github.com/RobEasthope"
   }
   ```

3. **homepage** - Direct link to documentation
   ```json
   "homepage": "https://github.com/RobEasthope/protomolecule#readme"
   ```

4. **bugs** - Issue reporting URL
   ```json
   "bugs": {
     "url": "https://github.com/RobEasthope/protomolecule/issues"
   }
   ```

## Impact

### 📈 Improved Discoverability
- Packages will appear in npm search for relevant keywords
- Better search ranking for terms like "react components", "tailwind ui", "eslint config"
- Clearer package purpose from keywords

### 📧 Clear Support Channels
- Users know where to report issues
- Direct link to project homepage
- Author attribution visible on npm

### 📦 All Critical Fields Already Present
This PR addresses the "important" fields for discoverability. All critical fields required for publishing were already present:
- ✅ name, version, description, license
- ✅ main/module/exports, files, repository

## Commits

1. feat(ui): add package metadata fields
2. feat(eslint-config): add package metadata fields  
3. feat(colours): add package metadata fields
4. chore: add changeset for package metadata

## Changeset

- Patch version bump for all 3 packages (metadata-only changes)

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)