### PR TITLE
docs(claude): clarify when changesets are required

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ Create a changeset **ONLY** when you modify source code in `packages/*/src/` or 
 - Adding/modifying components in `packages/ui/src/`
 - Changing ESLint rules in `packages/eslint-config/`
 - Updating color exports in `packages/colours/`
+- **Modifying `packages/*/package.json`** (dependencies, exports, scripts)
 - Modifying package-specific configuration that affects consumers
 - Updating package dependencies that affect functionality
 
@@ -134,6 +135,8 @@ Create a changeset **ONLY** when you modify source code in `packages/*/src/` or 
 ### Important Rules
 
 **CRITICAL:** Never include the root package name (e.g., `"protomolecule"`) in changesets. Only include scoped package names that start with `@protomolecule/`. The root package in a monorepo is not versioned or published.
+
+**CI Enforcement:** The changeset check runs automatically on all PRs. PRs modifying `packages/` without a changeset will fail CI.
 
 **Published to NPM:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,15 +78,37 @@ for consistency with design system naming conventions
 
 ## Changeset Requirements
 
-When creating PRs that modify any package:
+### When Changesets ARE Required
 
-1. **Always create a changeset file** before pushing the PR
-2. **Determine version bump** based on your changes:
+Create a changeset **ONLY** when you modify source code in `packages/*/src/` or package-specific files that affect published packages:
+
+- Adding/modifying components in `packages/ui/src/`
+- Changing ESLint rules in `packages/eslint-config/`
+- Updating color exports in `packages/colours/`
+- Modifying package-specific configuration that affects consumers
+- Updating package dependencies that affect functionality
+
+### When Changesets ARE NOT Required
+
+**DO NOT** create changesets for:
+
+- ❌ Root `package.json` script changes
+- ❌ `.github/` directory changes (workflows, scripts, actions)
+- ❌ Root configuration files (`.prettierrc`, `.eslintrc`, etc.)
+- ❌ Documentation updates (`*.md` files)
+- ❌ Build/test tooling configuration at root level
+- ❌ CI/CD configuration changes
+- ❌ Git hooks or linting configuration
+- ❌ Any changes that only affect development workflow, not published packages
+
+### Creating Changesets
+
+1. **Determine version bump** based on your changes:
    - `patch`: Bug fixes, dependency updates, small improvements
    - `minor`: New features, new components, new exports
    - `major`: Breaking changes, API changes, major refactors
 
-3. **Create changeset programmatically:**
+2. **Create changeset programmatically:**
 
    ```bash
    # Option 1: Use interactive CLI (if available)
@@ -102,16 +124,16 @@ When creating PRs that modify any package:
    EOF
    ```
 
-4. **Include changeset in your commits:**
+3. **Include changeset in your commits:**
 
    ```bash
    git add .changeset/*.md
    git commit -m "chore: add changeset"
    ```
 
-5. **CI will block PRs without changesets** - this is mandatory
+### Important Rules
 
-**IMPORTANT:** Never include the root package name (e.g., `"protomolecule"`) in changesets. Only include scoped package names that start with `@protomolecule/`. The root package in a monorepo is not versioned or published.
+**CRITICAL:** Never include the root package name (e.g., `"protomolecule"`) in changesets. Only include scoped package names that start with `@protomolecule/`. The root package in a monorepo is not versioned or published.
 
 **Published to NPM:**
 
@@ -120,6 +142,8 @@ When creating PRs that modify any package:
 - `@protomolecule/colours` - Radix UI color system
 
 **Private packages** (`tsconfig`, `github-rulesets`) still require changesets for version tracking but are not published to NPM.
+
+**When in doubt:** If you're only modifying files at the repository root level or in `.github/`, you almost certainly don't need a changeset.
 
 ## Monorepo Structure
 


### PR DESCRIPTION
## Summary

This PR clarifies the changeset requirements in CLAUDE.md to prevent incorrect changesets from being created for infrastructure changes.

### Changes Made

- Added **"When Changesets ARE Required"** section with explicit criteria
- Added **"When Changesets ARE NOT Required"** section with clear examples (root files, `.github/`, docs, etc.)
- Restructured the section for better clarity
- Added a "when in doubt" guideline
- Changed "IMPORTANT" to "CRITICAL" for the root package warning

### Problem Addressed

In PR #166, a changeset was incorrectly created for moving test scripts from `scripts/` to `.github/scripts/`. This change only affected:
- Root `package.json` script paths
- `.github/` directory structure

These are infrastructure changes that don't affect any published packages, so no changeset should have been created. The previous documentation said "When creating PRs that modify any package" which was ambiguous about what constitutes modifying a package.

### Benefits

- **Prevents unnecessary version bumps** for published packages
- **Clearer guidance** with explicit do/don't lists
- **Reduces noise** in changelogs by excluding infrastructure changes
- **Easier decision making** with visual indicators (❌) for what to avoid

## Test plan

- [x] Documentation is clear and unambiguous
- [x] Examples cover common scenarios
- [ ] Future PRs with infrastructure changes should not include changesets

No changeset included with this PR (following the new rules - this is a documentation-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)