### PR TITLE
feat(markdownlint-config): add shareable markdownlint configuration package

### DIFF
--- a/.changeset/add-markdownlint-config-package.md
+++ b/.changeset/add-markdownlint-config-package.md
@@ -1,0 +1,10 @@
+---
+"@robeasthope/markdownlint-config": minor
+---
+
+feat(markdownlint-config): add shareable markdownlint configuration package
+
+- Created new `@robeasthope/markdownlint-config` package for consistent Markdown formatting
+- Extracted configuration from root `.markdownlint-cli2.jsonc`
+- Updated root and all package configs to extend from the new shared package
+- Provides sensible defaults with flexibility for documentation needs

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,20 +1,6 @@
 {
   "config": {
-    "default": true,
-    "MD003": { "style": "atx" },
-    "MD007": { "indent": 2 },
-    "MD013": false,
-    "MD024": {
-      "siblings_only": true,
-    },
-    "MD029": false,
-    "MD031": false,
-    "MD033": false,
-    "MD034": false,
-    "MD036": false,
-    "MD040": true,
-    "MD041": false,
-    "MD051": false,
+    "extends": "@robeasthope/markdownlint-config",
   },
   "globs": [
     "**/*.{md,mdx}",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@changesets/cli": "^2.29.7",
     "@changesets/get-github-info": "^0.6.0",
     "@robeasthope/eslint-config": "workspace:*",
+    "@robeasthope/markdownlint-config": "workspace:*",
     "@robeasthope/tsconfig": "workspace:*",
     "@types/node": "^22.18.1",
     "@typescript-eslint/eslint-plugin": "^8.43.0",

--- a/packages/colours/.markdownlint-cli2.jsonc
+++ b/packages/colours/.markdownlint-cli2.jsonc
@@ -1,20 +1,6 @@
 {
   "config": {
-    "default": true,
-    "MD003": { "style": "atx" },
-    "MD007": { "indent": 2 },
-    "MD013": false,
-    "MD024": {
-      "siblings_only": true,
-    },
-    "MD029": false,
-    "MD031": false,
-    "MD033": false,
-    "MD034": false,
-    "MD036": false,
-    "MD040": true,
-    "MD041": false,
-    "MD051": false,
+    "extends": "@robeasthope/markdownlint-config",
   },
   "globs": [
     "**/*.{md,mdx}",

--- a/packages/eslint-config/.markdownlint-cli2.jsonc
+++ b/packages/eslint-config/.markdownlint-cli2.jsonc
@@ -1,20 +1,6 @@
 {
   "config": {
-    "default": true,
-    "MD003": { "style": "atx" },
-    "MD007": { "indent": 2 },
-    "MD013": false,
-    "MD024": {
-      "siblings_only": true,
-    },
-    "MD029": false,
-    "MD031": false,
-    "MD033": false,
-    "MD034": false,
-    "MD036": false,
-    "MD040": true,
-    "MD041": false,
-    "MD051": false,
+    "extends": "@robeasthope/markdownlint-config",
   },
   "globs": [
     "**/*.{md,mdx}",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -58,6 +58,7 @@
     "typescript-eslint": "^8.42.0"
   },
   "devDependencies": {
+    "@robeasthope/markdownlint-config": "workspace:*",
     "@robeasthope/tsconfig": "workspace:*",
     "@types/eslint": "^9.6.1",
     "@types/node": "^20.12.12",

--- a/packages/github-rulesets/.markdownlint-cli2.jsonc
+++ b/packages/github-rulesets/.markdownlint-cli2.jsonc
@@ -1,20 +1,6 @@
 {
   "config": {
-    "default": true,
-    "MD003": { "style": "atx" },
-    "MD007": { "indent": 2 },
-    "MD013": false,
-    "MD024": {
-      "siblings_only": true,
-    },
-    "MD029": false,
-    "MD031": false,
-    "MD033": false,
-    "MD034": false,
-    "MD036": false,
-    "MD040": true,
-    "MD041": false,
-    "MD051": false,
+    "extends": "@robeasthope/markdownlint-config",
   },
   "globs": [
     "**/*.{md,mdx}",

--- a/packages/github-rulesets/package.json
+++ b/packages/github-rulesets/package.json
@@ -15,6 +15,7 @@
     "sort-pkg-json": "npx sort-package-json"
   },
   "devDependencies": {
+    "@robeasthope/markdownlint-config": "workspace:*",
     "@robeasthope/tsconfig": "workspace:*",
     "rimraf": "^6.0.1"
   }

--- a/packages/markdownlint-config/.markdownlint-cli2.jsonc
+++ b/packages/markdownlint-config/.markdownlint-cli2.jsonc
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "extends": "./.markdownlint.json",
+  },
+  "globs": ["**/*.{md,mdx}", "!**/node_modules/**", "!**/dist/**"],
+}

--- a/packages/markdownlint-config/.markdownlint.json
+++ b/packages/markdownlint-config/.markdownlint.json
@@ -1,0 +1,15 @@
+{
+  "default": true,
+  "MD003": { "style": "atx" },
+  "MD007": { "indent": 2 },
+  "MD013": false,
+  "MD024": { "siblings_only": true },
+  "MD029": false,
+  "MD031": false,
+  "MD033": false,
+  "MD034": false,
+  "MD036": false,
+  "MD040": true,
+  "MD041": false,
+  "MD051": false
+}

--- a/packages/markdownlint-config/CHANGELOG.md
+++ b/packages/markdownlint-config/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @robeasthope/markdownlint-config
+
+## 1.0.0
+
+### Major Changes
+
+- Initial release of shareable markdownlint configuration
+- Extracted configuration from root `.markdownlint-cli2.jsonc`
+- Enables consistent Markdown formatting across projects
+- Sensible defaults with flexibility for documentation needs

--- a/packages/markdownlint-config/README.md
+++ b/packages/markdownlint-config/README.md
@@ -1,0 +1,164 @@
+# @robeasthope/markdownlint-config
+
+Shared markdownlint configuration for consistent Markdown formatting across projects.
+
+## 📦 Installation
+
+```bash
+npm install --save-dev @robeasthope/markdownlint-config
+# or
+pnpm add -D @robeasthope/markdownlint-config
+# or
+yarn add -D @robeasthope/markdownlint-config
+```
+
+## 🚀 Usage
+
+### Option 1: Direct Extension (Recommended)
+
+Create a `.markdownlint-cli2.jsonc` file in your project root:
+
+```jsonc
+{
+  "config": {
+    "extends": "@robeasthope/markdownlint-config",
+  },
+  "globs": ["**/*.{md,mdx}", "!**/node_modules/**", "!**/dist/**"],
+}
+```
+
+### Option 2: Extend in .markdownlint.json
+
+Create or update `.markdownlint.json`:
+
+```json
+{
+  "extends": "@robeasthope/markdownlint-config"
+}
+```
+
+### Option 3: Package.json Configuration
+
+Add to your `package.json`:
+
+```json
+{
+  "markdownlint-cli2": {
+    "config": {
+      "extends": "@robeasthope/markdownlint-config"
+    },
+    "globs": ["**/*.{md,mdx}"]
+  }
+}
+```
+
+## 📝 Configuration Details
+
+This configuration enforces consistent Markdown formatting with sensible defaults:
+
+### Enabled Rules
+
+- **MD003**: ATX-style headings (`# Heading`)
+- **MD007**: Unordered list indentation (2 spaces)
+- **MD040**: Fenced code blocks must specify language
+- **Default rules**: All standard markdownlint rules enabled by default
+
+### Disabled Rules
+
+- **MD013**: Line length (disabled for flexibility)
+- **MD024**: Multiple headings with same content (only enforced for siblings)
+- **MD029**: Ordered list item prefix (flexible numbering)
+- **MD031**: Fenced code blocks surrounded by blank lines (disabled)
+- **MD033**: Inline HTML (allowed)
+- **MD034**: Bare URL detection (disabled)
+- **MD036**: Emphasis as heading (disabled)
+- **MD041**: First line heading requirement (disabled)
+- **MD051**: Link fragments (disabled)
+
+## 🛠️ Customization
+
+Override specific rules by extending the configuration:
+
+```jsonc
+{
+  "config": {
+    "extends": "@robeasthope/markdownlint-config",
+    "MD013": { "line_length": 100 }, // Enable line length with custom limit
+    "MD033": false, // Disable inline HTML
+  },
+}
+```
+
+## 📋 NPM Scripts
+
+Add these scripts to your `package.json`:
+
+```json
+{
+  "scripts": {
+    "lint:md": "markdownlint-cli2",
+    "lint:md:fix": "markdownlint-cli2 --fix"
+  }
+}
+```
+
+Then run:
+
+```bash
+# Check Markdown files
+pnpm lint:md
+
+# Auto-fix issues
+pnpm lint:md:fix
+```
+
+## 🔗 Integration
+
+### With Husky and lint-staged
+
+Add to `.lintstagedrc.json`:
+
+```json
+{
+  "*.{md,mdx}": ["markdownlint-cli2 --fix"]
+}
+```
+
+### With VS Code
+
+Install the [markdownlint extension](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) and the configuration will be automatically detected.
+
+## 📖 Rule Reference
+
+For detailed rule documentation, see:
+
+- [Markdownlint Rules](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md)
+- [Markdownlint CLI2](https://github.com/DavidAnson/markdownlint-cli2)
+
+## 🎯 Philosophy
+
+This configuration aims to:
+
+1. **Enforce consistency** in heading styles and list formatting
+2. **Allow flexibility** in line length and HTML usage for documentation needs
+3. **Prevent common errors** like missing code fence language tags
+4. **Stay unobtrusive** by disabling overly strict rules
+
+## 📁 Package Structure
+
+```text
+packages/markdownlint-config/
+├── .markdownlint.json      # Shared configuration
+├── package.json
+└── README.md
+```
+
+## 🤝 Contributing
+
+Found an issue or want to suggest a rule change? Please open an issue in the repository.
+
+## 📄 License
+
+MIT License - see [LICENSE](../../LICENSE) file in the root directory.
+
+This software is provided "as is", without warranty of any kind. Use at your own risk.

--- a/packages/markdownlint-config/package.json
+++ b/packages/markdownlint-config/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "@robeasthope/colours",
-  "version": "3.0.0",
-  "description": "Radix colors CSS imports for Protomolecule projects",
+  "name": "@robeasthope/markdownlint-config",
+  "version": "1.0.0",
+  "description": "Shared markdownlint configuration for consistent Markdown formatting",
   "keywords": [
-    "colors",
-    "colours",
-    "radix-ui",
-    "design-tokens",
-    "css",
-    "theme"
+    "markdownlint",
+    "markdown",
+    "linting",
+    "formatting",
+    "code-quality",
+    "style-guide"
   ],
   "homepage": "https://github.com/RobEasthope/protomolecule#readme",
   "bugs": {
@@ -17,16 +17,17 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/RobEasthope/protomolecule.git",
-    "directory": "packages/colours"
+    "directory": "packages/markdownlint-config"
   },
   "license": "MIT",
   "author": {
     "name": "Rob Easthope",
     "url": "https://github.com/RobEasthope"
   },
-  "main": "index.css",
+  "main": ".markdownlint.json",
   "files": [
-    "index.css"
+    ".markdownlint.json",
+    "README.md"
   ],
   "scripts": {
     "clean": "rimraf node_modules",
@@ -35,12 +36,8 @@
     "lint:md:fix": "markdownlint-cli2 --fix",
     "sort-pkg-json": "npx sort-package-json"
   },
-  "dependencies": {
-    "@radix-ui/colors": "^3.0.0"
-  },
   "devDependencies": {
-    "@robeasthope/markdownlint-config": "workspace:*",
-    "@robeasthope/tsconfig": "workspace:*",
+    "markdownlint-cli2": "^0.18.1",
     "rimraf": "^6.0.1"
   },
   "publishConfig": {

--- a/packages/tsconfig/.markdownlint-cli2.jsonc
+++ b/packages/tsconfig/.markdownlint-cli2.jsonc
@@ -1,20 +1,6 @@
 {
   "config": {
-    "default": true,
-    "MD003": { "style": "atx" },
-    "MD007": { "indent": 2 },
-    "MD013": false,
-    "MD024": {
-      "siblings_only": true,
-    },
-    "MD029": false,
-    "MD031": false,
-    "MD033": false,
-    "MD034": false,
-    "MD036": false,
-    "MD040": true,
-    "MD041": false,
-    "MD051": false,
+    "extends": "@robeasthope/markdownlint-config",
   },
   "globs": [
     "**/*.{md,mdx}",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -16,6 +16,7 @@
     "sort-pkg-json": "npx sort-package-json"
   },
   "devDependencies": {
+    "@robeasthope/markdownlint-config": "workspace:*",
     "rimraf": "^6.0.1"
   }
 }

--- a/packages/ui/.markdownlint-cli2.jsonc
+++ b/packages/ui/.markdownlint-cli2.jsonc
@@ -1,20 +1,6 @@
 {
   "config": {
-    "default": true,
-    "MD003": { "style": "atx" },
-    "MD007": { "indent": 2 },
-    "MD013": false,
-    "MD024": {
-      "siblings_only": true,
-    },
-    "MD029": false,
-    "MD031": false,
-    "MD033": false,
-    "MD034": false,
-    "MD036": false,
-    "MD040": true,
-    "MD041": false,
-    "MD051": false,
+    "extends": "@robeasthope/markdownlint-config",
   },
   "globs": [
     "**/*.{md,mdx}",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -80,6 +80,7 @@
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.1",
     "@robeasthope/eslint-config": "workspace:*",
+    "@robeasthope/markdownlint-config": "workspace:*",
     "@robeasthope/tsconfig": "workspace:*",
     "@storybook/addon-docs": "^9.1.3",
     "@storybook/addon-links": "^9.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       "@robeasthope/eslint-config":
         specifier: workspace:*
         version: link:packages/eslint-config
+      "@robeasthope/markdownlint-config":
+        specifier: workspace:*
+        version: link:packages/markdownlint-config
       "@robeasthope/tsconfig":
         specifier: workspace:*
         version: link:packages/tsconfig
@@ -71,6 +74,9 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
     devDependencies:
+      "@robeasthope/markdownlint-config":
+        specifier: workspace:*
+        version: link:../markdownlint-config
       "@robeasthope/tsconfig":
         specifier: workspace:*
         version: link:../tsconfig
@@ -96,6 +102,9 @@ importers:
         specifier: ^8.42.0
         version: 8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.4.5)
     devDependencies:
+      "@robeasthope/markdownlint-config":
+        specifier: workspace:*
+        version: link:../markdownlint-config
       "@robeasthope/tsconfig":
         specifier: workspace:*
         version: link:../tsconfig
@@ -117,6 +126,9 @@ importers:
 
   packages/github-rulesets:
     devDependencies:
+      "@robeasthope/markdownlint-config":
+        specifier: workspace:*
+        version: link:../markdownlint-config
       "@robeasthope/tsconfig":
         specifier: workspace:*
         version: link:../tsconfig
@@ -124,8 +136,20 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
 
+  packages/markdownlint-config:
+    devDependencies:
+      markdownlint-cli2:
+        specifier: ^0.18.1
+        version: 0.18.1
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
+
   packages/tsconfig:
     devDependencies:
+      "@robeasthope/markdownlint-config":
+        specifier: workspace:*
+        version: link:../markdownlint-config
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
@@ -184,6 +208,9 @@ importers:
       "@robeasthope/eslint-config":
         specifier: workspace:*
         version: link:../eslint-config
+      "@robeasthope/markdownlint-config":
+        specifier: workspace:*
+        version: link:../markdownlint-config
       "@robeasthope/tsconfig":
         specifier: workspace:*
         version: link:../tsconfig


### PR DESCRIPTION
## Summary

- Created new `@robeasthope/markdownlint-config` package for consistent Markdown formatting
- Extracted configuration from root `.markdownlint-cli2.jsonc` to make it shareable
- Updated root and all package-level configs to extend from new shared package
- Added package as workspace dependency to all packages using markdownlint
- Provides sensible defaults with flexibility for documentation needs

## Benefits

- **Centralized configuration**: Single source of truth for markdownlint rules
- **Easy updates**: Change rules in one place, applied everywhere
- **Publishable**: Can be used in external projects via npm
- **Consistent formatting**: All packages follow the same Markdown style

## Changes

### New Package
- `packages/markdownlint-config/` with complete package structure
- `.markdownlint.json` with extracted configuration rules
- Comprehensive README with usage instructions
- Added to workspace dependencies

### Configuration Updates
- Simplified all `.markdownlint-cli2.jsonc` files to extend from package
- Root configuration now uses `extends: "@robeasthope/markdownlint-config"`
- All package configs updated to use shared configuration

### Testing
- ✅ All markdownlint tests pass
- ✅ Configuration resolves correctly across all packages
- ✅ Formatting and linting successful

## Test plan

- [x] Create new package structure
- [x] Extract configuration rules
- [x] Update all configs to extend from new package
- [x] Run `pnpm install` to link workspace package
- [x] Test with `pnpm lint:md` - all tests pass
- [x] Run `pnpm format` - all files formatted correctly
- [x] Create changeset for minor version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)