### PR TITLE
fix(eslint-config): use targeted regex for Astro virtual imports

### DIFF
--- a/.changeset/astro-virtual-imports-support.md
+++ b/.changeset/astro-virtual-imports-support.md
@@ -1,0 +1,5 @@
+---
+"@robeasthope/eslint-config": patch
+---
+
+Improve Astro support by ignoring virtual imports (astro:*) instead of disabling import resolution entirely. The import/no-unresolved rule now uses a targeted regex pattern to allow Astro's virtual modules (astro:content, astro:assets, etc.) while still validating other imports in .astro files.

--- a/packages/eslint-config/rules/astro.ts
+++ b/packages/eslint-config/rules/astro.ts
@@ -7,6 +7,15 @@ export const astro = [
     files: ["**/*.astro"],
     rules: {
       "astro/no-set-html-directive": "error",
+      // Allow Astro virtual imports (astro:*) while still checking other imports
+      "import/no-unresolved": [
+        "error",
+        {
+          ignore: [
+            "^astro:", // Astro virtual modules (astro:content, astro:assets, etc.)
+          ],
+        },
+      ],
     },
   } satisfies Linter.Config,
 ];


### PR DESCRIPTION
## Summary

- Instead of disabling `import/no-unresolved` entirely for `.astro` files, use a targeted regex pattern to ignore only Astro's virtual modules
- The pattern `^astro:` allows virtual imports like `astro:content`, `astro:assets`, etc.
- Regular imports in `.astro` files are still validated, maintaining protection against typos and missing dependencies

## Changes

- Added `import/no-unresolved` rule configuration in `packages/eslint-config/rules/astro.ts`
- Uses `ignore` option with regex pattern `^astro:` to specifically target virtual modules
- Includes changeset for patch version bump

## Benefits

- **More precise:** Only ignores problematic virtual imports, not all import resolution
- **Maintains safety:** Regular imports are still checked, catching legitimate errors
- **Better DX:** Works out of the box with Astro projects without requiring user configuration

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)