### PR TITLE
refactor(ui): deprecate Box component in favor of standard HTML

### DIFF
--- a/.changeset/deprecate-box-component.md
+++ b/.changeset/deprecate-box-component.md
@@ -1,0 +1,25 @@
+---
+"@robeasthope/ui": minor
+---
+
+Deprecate Box component in favor of standard HTML elements. The component remains exported for backward compatibility but should not be used in new code.
+
+**Migration guide:**
+
+For static elements:
+```tsx
+{children && <div className={cn("...")}>{children}</div>}
+```
+
+For dynamic elements:
+```tsx
+{children && createElement(as, { className: cn("...") }, children)}
+```
+
+**Changes:**
+
+- Added `@deprecated` JSDoc to Box component with migration examples
+- Updated SanityProse to use `createElement` instead of Box
+- Box component will be removed in a future major version
+
+See issue #187 for full migration guide.

--- a/packages/ui/components/Box/Box.test.tsx
+++ b/packages/ui/components/Box/Box.test.tsx
@@ -1,6 +1,10 @@
 import { Box } from "./Box";
 import { render, screen } from "@testing-library/react";
 
+/**
+ * @deprecated Box component is deprecated. These tests remain for backward compatibility.
+ * @see https://github.com/RobEasthope/protomolecule/issues/187
+ */
 describe("Box", () => {
   it("renders children correctly", () => {
     render(<Box as="div">Lorem ipsum</Box>);

--- a/packages/ui/components/Box/Box.tsx
+++ b/packages/ui/components/Box/Box.tsx
@@ -8,6 +8,20 @@ export type BoxProps = {
   readonly ref?: React.Ref<HTMLDivElement>;
 };
 
+/**
+ * @deprecated Box component is deprecated. Use standard HTML elements instead.
+ *
+ * For static elements:
+ * ```tsx
+ * {children && <div className={cn("...")}>{children}</div>}
+ * ```
+ *
+ * For dynamic elements:
+ * ```tsx
+ * {children && createElement(as, { className: cn("...") }, children)}
+ * ```
+ * @see https://github.com/RobEasthope/protomolecule/issues/187
+ */
 export function Box({
   as = "div",
   children,

--- a/packages/ui/components/SanityProse/SanityProse.tsx
+++ b/packages/ui/components/SanityProse/SanityProse.tsx
@@ -1,6 +1,6 @@
-import { Box } from "@/components/Box/Box";
 import { cn } from "@/utils/tailwind";
 import { PortableText, type PortableTextComponents } from "@portabletext/react";
+import { createElement } from "react";
 import { type TypedObject } from "sanity";
 
 export type SanityProseProps = {
@@ -20,12 +20,12 @@ export function SanityProse({
     return null;
   }
 
-  return (
-    <Box as={as} className={cn("prose", "text-ink", className)}>
-      <PortableText
-        components={components as PortableTextComponents}
-        value={content}
-      />
-    </Box>
+  return createElement(
+    as,
+    { className: cn("prose", "text-ink", className) },
+    <PortableText
+      components={components as PortableTextComponents}
+      value={content}
+    />,
   );
 }


### PR DESCRIPTION
## Summary

Deprecates the `Box` component while maintaining backward compatibility. The component remains exported but is marked with `@deprecated` JSDoc and should not be used in new code.

Fixes #187

## Changes

- Added `@deprecated` JSDoc to Box component with migration examples
- Updated SanityProse to use `createElement` instead of Box
- Added deprecation notice to Box tests
- Created `minor` changeset documenting the deprecation

## Migration Examples

### For static elements
```tsx
{children && <div className={cn("...")}>{children}</div>}
```

### For dynamic elements
```tsx
{children && createElement(as, { className: cn("...") }, children)}
```

## Test Plan

- [x] All existing tests pass (64 tests across 9 files)
- [x] SanityProse correctly renders with `createElement`
- [x] Box component still works for backward compatibility
- [x] TypeScript builds without errors

## Breaking Changes

None - Box component remains exported for backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)