### PR TITLE
docs(github-rulesets): add warning about customizing status check names

### DIFF
--- a/.changeset/status-check-warning.md
+++ b/.changeset/status-check-warning.md
@@ -1,0 +1,7 @@
+---
+"@robeasthope/github-rulesets": patch
+---
+
+Add warning about customizing status check names before applying rulesets
+
+Added prominent warning section to README explaining that hardcoded status check names (Lint, Build, Test, Changeset Check) must match GitHub Actions workflow job names exactly. Includes instructions for both updating the ruleset JSON and updating workflows to match.

--- a/packages/github-rulesets/README.md
+++ b/packages/github-rulesets/README.md
@@ -33,6 +33,55 @@ The production ruleset enforces:
 - **No Deletions**: Protected branches cannot be deleted
 - **Linear History**: Enforces merge commits or rebase, no merge bubbles
 
+## ⚠️ Important: Customize Before Applying
+
+**Status Check Names Must Match Your CI/CD Workflows**
+
+The production ruleset includes hardcoded status check names that must match your GitHub Actions workflow job names **exactly**:
+
+- `Lint`
+- `Build`
+- `Test`
+- `Changeset Check`
+
+### Before Applying to a Repository
+
+**Option 1: Update the Ruleset (Recommended)**
+
+Edit `rulesets/Protect production ruleset.json` to match your workflow job names:
+
+```json
+{
+  "type": "required_status_checks",
+  "parameters": {
+    "required_status_checks": [
+      {
+        "context": "Your-Lint-Job-Name",
+        "integration_id": 15368
+      }
+    ]
+  }
+}
+```
+
+**Option 2: Update Your Workflows**
+
+Ensure your GitHub Actions workflows use the exact job names from the ruleset:
+
+```yaml
+jobs:
+  Lint: # Must match "Lint" in ruleset exactly
+    name: Lint
+    runs-on: ubuntu-latest
+    # ...
+```
+
+**⚠️ Failure to match names will result in:**
+
+- Required status checks that never complete
+- Pull requests blocked from merging
+- CI checks that pass but don't satisfy ruleset requirements
+
 ## 🛠️ How to Apply Rulesets
 
 ### Via Scripts (Recommended)


### PR DESCRIPTION
## Summary

Fixes #195

Adds a prominent warning section to the README explaining that hardcoded status check names must match GitHub Actions workflow job names exactly.

## Changes

- ✅ Added "⚠️ Important: Customize Before Applying" section before "How to Apply Rulesets"
- ✅ Lists the 4 hardcoded status check names (Lint, Build, Test, Changeset Check)
- ✅ Provides two options:
  1. Update the ruleset JSON to match your workflow names (recommended)
  2. Update your workflows to match the ruleset names
- ✅ Explains consequences of mismatched names (blocked PRs, checks never complete)
- ✅ Includes code examples for both JSON and YAML updates

## Test Plan

- [x] Changeset created for patch version bump
- [x] Documentation renders correctly in Markdown
- [x] Warning is prominent and appears before usage instructions

## Screenshots

The warning section now appears prominently before users attempt to apply rulesets, preventing the common pitfall of mismatched status check names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)