### PR TITLE
fix(ci): skip Claude Code reviews for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
+    # Skip Claude Code reviews for Dependabot PRs (they don't have access to secrets)
+    # and only run for specific contributors if needed
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    # Optional: Additional filters
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||


### PR DESCRIPTION
## Summary

Fixes failing Claude Code review workflow on Dependabot PRs by skipping the review entirely for Dependabot-created pull requests.

## Problem

Dependabot PRs were failing the Claude Code review workflow with:
```
Environment variable validation failed:
  - Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required
```

## Root Cause

GitHub doesn't pass repository secrets to workflows triggered by Dependabot PRs for security reasons. This is a platform security feature to prevent Dependabot from accessing sensitive credentials.

Even though the workflow file correctly passes the token via `with: claude_code_oauth_token`, the secret itself is unavailable in Dependabot-triggered workflows, resulting in an empty token value.

## Solution

Added a conditional check to skip Claude Code reviews for Dependabot PRs:

```yaml
if: github.event.pull_request.user.login != 'dependabot[bot]'
```

This is appropriate because:
- Dependency updates are typically straightforward and don't require AI code review
- Other CI checks (linting, tests, builds) still run normally
- Manual review can still approve/merge the PR

## Testing

Once merged, Dependabot PRs will skip the Claude Code review step entirely, preventing the failures. Regular PRs from human contributors will continue to receive Claude Code reviews as normal.

## Related

- Closes issues with PRs #217-221 failing Claude Code review
- Follows GitHub's recommended pattern for handling Dependabot secret access

🤖 Generated with [Claude Code](https://claude.com/claude-code)