### PR TITLE
feat(dev): add Act for local GitHub Actions workflow testing

### DIFF
--- a/.actrc.example
+++ b/.actrc.example
@@ -1,0 +1,18 @@
+# Act Configuration Example
+# Copy this file to .actrc and customize as needed
+# .actrc is git-ignored to keep local settings private
+
+# Container architecture (use linux/amd64 for Apple Silicon compatibility)
+--container-architecture linux/amd64
+
+# Artifact server path for workflow artifacts
+--artifact-server-path /tmp/artifacts
+
+# Default runner image (Medium: ~500MB, good balance of size and compatibility)
+-P ubuntu-latest=catthehacker/ubuntu:act-latest
+
+# Optional: Use a secrets file (ensure .secrets is in .gitignore!)
+# --secret-file .secrets
+
+# For more configuration options, see:
+# https://nektosact.com/usage/index.html#configuration-file

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ SPEC.md
 # TypeScript build info
 *.tsbuildinfo
 .tsbuildinfo
+
+# Act (GitHub Actions local runner)
+.actrc
+.secrets

--- a/README.md
+++ b/README.md
@@ -99,6 +99,68 @@ All commands run from the monorepo root:
 
 See the [Development Guide](./docs/development.md) for a complete list of available scripts.
 
+## 🧪 Testing Workflows Locally
+
+The project uses [Act](https://github.com/nektos/act) to run GitHub Actions workflows locally. This enables faster iteration and debugging without requiring push/PR cycles.
+
+### Prerequisites
+
+- **Docker Desktop** must be running
+- **Act** installed via Homebrew: `brew install act`
+- **Configuration**: Copy `.actrc.example` to `.actrc` for local settings
+
+### Quick Start
+
+```bash
+# Copy example configuration
+cp .actrc.example .actrc
+
+# List all available workflows
+act -l
+
+# Test CI workflow (dry run)
+act pull_request -W .github/workflows/linting-and-testing.yml -n
+
+# Run push event workflows
+act push
+
+# Run specific job
+act -j build
+
+# Verbose output for debugging
+act push --verbose
+```
+
+### Common Workflows
+
+```bash
+# Test linting and testing workflow
+act pull_request -W .github/workflows/linting-and-testing.yml
+
+# Test release workflow
+act push -W .github/workflows/release.yml
+
+# Run with secrets (interactive prompt)
+act -s GITHUB_TOKEN
+```
+
+### Important Notes
+
+- **First run downloads Docker images** (~500MB) - subsequent runs are much faster
+- **Secrets** need to be provided via `-s` flag or `.secrets` file (git-ignored)
+- **Not 100% identical** to GitHub Actions - some features may behave slightly differently
+
+### Troubleshooting
+
+| Issue                               | Solution                                                            |
+| ----------------------------------- | ------------------------------------------------------------------- |
+| "Cannot connect to Docker daemon"   | Ensure Docker Desktop is running                                    |
+| Workflow fails with missing secrets | Pass secrets via `-s GITHUB_TOKEN` or create `.secrets` file        |
+| "No workflows detected"             | Specify workflow file: `act -W .github/workflows/workflow-name.yml` |
+| First run is very slow              | Expected - downloading Docker images (~500MB)                       |
+
+For more information, see the [Act documentation](https://nektosact.com/usage/index.html).
+
 ## 🏗️ Tech Stack
 
 - **Monorepo**: [Turborepo](https://turbo.build/)


### PR DESCRIPTION
## Summary

Add [Act](https://github.com/nektos/act) configuration to enable local testing of GitHub Actions workflows without requiring push/PR cycles.

## Motivation

Testing workflow changes currently requires:
1. Push changes to GitHub
2. Wait for workflow to run
3. Check logs for errors
4. Fix and repeat

This is slow and creates noisy commit history. Act allows running workflows locally in Docker containers that closely simulate GitHub's runners.

## Proven Success in Hecate

Act was recently implemented in the [hecate](https://github.com/RobEasthope/hecate) repository and immediately proved its value, discovering multiple configuration issues in < 5 minutes that would have each required a full CI cycle to identify.

Reference: [hecate#165](https://github.com/RobEasthope/hecate/issues/165), [hecate#167](https://github.com/RobEasthope/hecate/pull/167)

## Changes

- ✅ Created `.actrc.example` with recommended configuration for Apple Silicon
- ✅ Updated `.gitignore` to exclude `.actrc` and `.secrets` files  
- ✅ Added comprehensive "Testing Workflows Locally" section to README.md
- ✅ Includes prerequisites, quick start guide, common commands, and troubleshooting

## Testing

- Verified Act installation and Docker connectivity
- Successfully ran dry run of linting workflow: `act pull_request -W .github/workflows/linting-and-testing.yml -n`
- All jobs (lint, typecheck, test, changeset, summary) executed correctly

## Benefits

- **Faster iteration** - Test workflow changes in seconds, not minutes
- **Cleaner git history** - No "fix CI" commits
- **Debug workflows** - Step through workflow execution locally
- **Catch issues early** - Discover configuration problems before pushing

## Additional Notes

- First run downloads Docker images (~500MB) - subsequent runs are fast
- Secrets need to be provided via `-s` flag or `.secrets` file (git-ignored)
- Not 100% identical to GitHub Actions, but close enough for most testing

Resolves #222

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)