### PR TITLE
feat(ci): add pre-push hook to check for changesets

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+# Pre-push hook to check for changesets when packages are modified
+# This prevents pushing package changes without a changeset
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "🔍 Pre-push: Checking for changesets..."
+
+# Get the remote and branch being pushed to
+remote="$1"
+url="$2"
+
+# Read the push details from stdin
+while read local_ref local_sha remote_ref remote_sha
+do
+  # Skip if deleting a branch
+  if [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
+    exit 0
+  fi
+
+  # If remote_sha is all zeros, this is a new branch
+  if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+    # Compare against main/master branch
+    if git show-ref --verify --quiet refs/heads/main; then
+      base_branch="main"
+    elif git show-ref --verify --quiet refs/heads/master; then
+      base_branch="master"
+    else
+      # Can't determine base, allow push
+      echo "⚠️  Warning: Could not determine base branch, skipping changeset check"
+      exit 0
+    fi
+    range="$base_branch..$local_sha"
+  else
+    # Compare what we're about to push
+    range="$remote_sha..$local_sha"
+  fi
+
+  # Check if any packages have changed in this range
+  CHANGED_FILES=$(git diff --name-only $range 2>/dev/null)
+
+  if echo "$CHANGED_FILES" | grep -q "^packages/"; then
+    echo "${YELLOW}📝 Package changes detected${NC}"
+
+    # Check for changeset files (excluding README.md)
+    changeset_count=$(ls -1 .changeset/*.md 2>/dev/null | grep -v README.md | wc -l | tr -d ' ')
+
+    if [ "$changeset_count" -eq "0" ]; then
+      echo ""
+      echo "${RED}❌ Pre-push check failed!${NC}"
+      echo ""
+      echo "You're trying to push package changes without a changeset."
+      echo ""
+      echo "To fix this:"
+      echo "  1. Run: ${GREEN}pnpm changeset${NC}"
+      echo "  2. Select the affected packages"
+      echo "  3. Choose the version bump type (patch/minor/major)"
+      echo "  4. Describe your changes"
+      echo "  5. Commit the changeset file: ${GREEN}git add .changeset/*.md && git commit -m 'chore: add changeset'${NC}"
+      echo "  6. Push again: ${GREEN}git push${NC}"
+      echo ""
+      echo "To skip this check (not recommended): ${YELLOW}git push --no-verify${NC}"
+      echo ""
+      exit 1
+    else
+      echo "${GREEN}✅ Changeset found ($changeset_count file(s))${NC}"
+    fi
+  else
+    echo "${GREEN}✅ No package changes - changeset not required${NC}"
+  fi
+done
+
+echo "${GREEN}✅ Pre-push checks passed${NC}"
+exit 0


### PR DESCRIPTION
## Summary

- Adds Husky pre-push hook to validate changeset presence when pushing package changes
- Prevents accidental pushes of package modifications without proper version tracking
- Provides clear, actionable error messages with step-by-step instructions

## Changes

- Created `.husky/pre-push` hook that:
  - Detects modifications in `packages/` directory
  - Checks for changeset files in `.changeset/` (excluding README.md)
  - Blocks push if packages changed without changeset
  - Allows bypass with `--no-verify` flag when needed
  - Handles both new branches (compares vs main) and existing branches

## Test Plan

- [x] Tested hook with package changes but no changeset (correctly blocks)
- [x] Tested hook with package changes and changeset present (correctly allows)
- [x] Tested hook with no package changes (correctly allows)
- [x] Verified helpful error messages and instructions display correctly
- [x] Confirmed hook is executable and runs automatically on `git push`

## Benefits

- Enforces changeset discipline at the git level (earlier than CI)
- Provides immediate feedback before pushing to remote
- Complements existing CI changeset check
- Educational for developers unfamiliar with changeset workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)