### PR TITLE
fix(infrastructure): improve PR title regex precision

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,8 +191,10 @@ jobs:
           echo "Enhancing PR #${PR_NUMBER} with package information..."
 
           # Extract package names from the PR body text (changesets includes them there)
-          # This is more reliable than parsing diffs and works in CI without filesystem access
+          # Match only package release headers (## @package/name@version format)
+          # This avoids matching example package names in changeset descriptions
           PACKAGE_LIST=$(timeout 30s gh pr view "$PR_NUMBER" --json body -q ".body" | \
+            grep -E '^## @robeasthope/[a-z0-9-]+@' | \
             grep -oE '@robeasthope/[a-z0-9-]+' | \
             grep -v '@robeasthope/monorepo' | \
             sort -u | \


### PR DESCRIPTION
## Problem

PR #236 had an incorrect title: `release: @robeasthope/infrastructure,@robeasthope/package-name`

The regex was matching `@robeasthope/package-name` from the changeset description text, not just the actual package release header.

## Root Cause

The original regex `@robeasthope/[a-z0-9-]+` was too broad:
- It matched any occurrence of the package pattern anywhere in the PR body
- Changesets include the full changeset description in the PR body
- Our changeset description contained example text: `"release: @robeasthope/package-name,..."`

## Solution

Updated regex to match **only** release headers:
```bash
# Old (matches anywhere):
grep -oE '@robeasthope/[a-z0-9-]+'

# New (matches only headers):
grep -E '^## @robeasthope/[a-z0-9-]+@'
```

This specifically matches lines like:
- `## @robeasthope/infrastructure@2.0.1` ✅
- `## @robeasthope/ui@1.2.3` ✅

And ignores description text like:
- `to "release: @robeasthope/package-name,..."` ❌

## Testing

Tested with actual PR #236 body:
- **Old regex**: `@robeasthope/infrastructure,@robeasthope/package-name` ❌
- **New regex**: `@robeasthope/infrastructure` ✅

Also tested multiple packages scenario - works correctly.

## Additional Fix

Updated changeset description to avoid using example package names that could be matched by regex in future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)