### PR TITLE
refactor(infrastructure): rename to @protomolecule/infrastructure

### DIFF
--- a/.changeset/rename-infrastructure-package.md
+++ b/.changeset/rename-infrastructure-package.md
@@ -1,0 +1,9 @@
+---
+"@protomolecule/infrastructure": patch
+---
+
+Rename infrastructure package from @robeasthope/infrastructure to @protomolecule/infrastructure
+
+The `@robeasthope/*` namespace is reserved for packages published to npm. Since the infrastructure package is a virtual package (never published), it makes more sense to use the monorepo name `@protomolecule/*` to avoid confusion.
+
+This is a virtual package used only for version tracking - no code changes required.

--- a/.github/scripts/create-releases.test.ts
+++ b/.github/scripts/create-releases.test.ts
@@ -1,82 +1,85 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from "vitest";
 import {
   getChangelogPaths,
   findChangelogPath,
   extractChangelogContent,
   SEMVER_REGEX,
   PACKAGE_NAME_REGEX,
-  type FileExistsFn
-} from './create-releases';
+  type FileExistsFn,
+} from "./create-releases";
 
-describe('getChangelogPaths', () => {
-  it('returns infrastructure path for infrastructure package', () => {
-    const result = getChangelogPaths('@robeasthope/infrastructure');
+describe("getChangelogPaths", () => {
+  it("returns infrastructure path for infrastructure package", () => {
+    const result = getChangelogPaths("@protomolecule/infrastructure");
 
-    expect(result).toEqual(['infrastructure/CHANGELOG.md']);
+    expect(result).toEqual(["infrastructure/CHANGELOG.md"]);
   });
 
-  it('returns apps and packages paths for regular package', () => {
-    const result = getChangelogPaths('@robeasthope/markdown');
+  it("returns apps and packages paths for regular package", () => {
+    const result = getChangelogPaths("@robeasthope/markdown");
 
     expect(result).toEqual([
-      'apps/markdown/CHANGELOG.md',
-      'packages/markdown/CHANGELOG.md'
+      "apps/markdown/CHANGELOG.md",
+      "packages/markdown/CHANGELOG.md",
     ]);
   });
 
-  it('handles package with hyphens', () => {
-    const result = getChangelogPaths('@robeasthope/my-package');
+  it("handles package with hyphens", () => {
+    const result = getChangelogPaths("@robeasthope/my-package");
 
     expect(result).toEqual([
-      'apps/my-package/CHANGELOG.md',
-      'packages/my-package/CHANGELOG.md'
+      "apps/my-package/CHANGELOG.md",
+      "packages/my-package/CHANGELOG.md",
     ]);
   });
 });
 
-describe('findChangelogPath', () => {
-  it('returns first existing path', () => {
-    const mockExists: FileExistsFn = vi.fn((path: string) =>
-      path === 'apps/markdown/CHANGELOG.md'
+describe("findChangelogPath", () => {
+  it("returns first existing path", () => {
+    const mockExists: FileExistsFn = vi.fn(
+      (path: string) => path === "apps/markdown/CHANGELOG.md",
     );
 
-    const result = findChangelogPath('@robeasthope/markdown', mockExists);
+    const result = findChangelogPath("@robeasthope/markdown", mockExists);
 
-    expect(result).toBe('apps/markdown/CHANGELOG.md');
-    expect(mockExists).toHaveBeenCalledWith('apps/markdown/CHANGELOG.md');
+    expect(result).toBe("apps/markdown/CHANGELOG.md");
+    expect(mockExists).toHaveBeenCalledWith("apps/markdown/CHANGELOG.md");
   });
 
-  it('returns second path if first does not exist', () => {
-    const mockExists: FileExistsFn = vi.fn((path: string) =>
-      path === 'packages/ui/CHANGELOG.md'
+  it("returns second path if first does not exist", () => {
+    const mockExists: FileExistsFn = vi.fn(
+      (path: string) => path === "packages/ui/CHANGELOG.md",
     );
 
-    const result = findChangelogPath('@robeasthope/ui', mockExists);
+    const result = findChangelogPath("@robeasthope/ui", mockExists);
 
-    expect(result).toBe('packages/ui/CHANGELOG.md');
+    expect(result).toBe("packages/ui/CHANGELOG.md");
     expect(mockExists).toHaveBeenCalledTimes(2);
   });
 
-  it('returns null if no paths exist', () => {
+  it("returns null if no paths exist", () => {
     const mockExists: FileExistsFn = vi.fn(() => false);
 
-    const result = findChangelogPath('@robeasthope/nonexistent', mockExists);
+    const result = findChangelogPath("@robeasthope/nonexistent", mockExists);
 
     expect(result).toBeNull();
   });
 
-  it('handles infrastructure package', () => {
+  it("handles infrastructure package", () => {
     const mockExists: FileExistsFn = vi.fn(() => true);
 
-    const result = findChangelogPath('@robeasthope/infrastructure', mockExists);
+    const result = findChangelogPath(
+      "@protomolecule/infrastructure",
+      mockExists,
+    );
 
-    expect(result).toBe('infrastructure/CHANGELOG.md');
-    expect(mockExists).toHaveBeenCalledWith('infrastructure/CHANGELOG.md');
+    expect(result).toBe("infrastructure/CHANGELOG.md");
+    expect(mockExists).toHaveBeenCalledWith("infrastructure/CHANGELOG.md");
   });
 });
 
-describe('extractChangelogContent', () => {
-  it('extracts content for specific version', () => {
+describe("extractChangelogContent", () => {
+  it("extracts content for specific version", () => {
     const content = `## 1.2.0
 
 - Feature A
@@ -86,12 +89,12 @@ describe('extractChangelogContent', () => {
 
 - Old feature`;
 
-    const result = extractChangelogContent(content, '1.2.0');
+    const result = extractChangelogContent(content, "1.2.0");
 
-    expect(result).toBe('- Feature A\n- Feature B');
+    expect(result).toBe("- Feature A\n- Feature B");
   });
 
-  it('extracts last version (no next header)', () => {
+  it("extracts last version (no next header)", () => {
     const content = `## 2.0.0
 
 - Breaking change
@@ -100,22 +103,22 @@ describe('extractChangelogContent', () => {
 
 - Initial release`;
 
-    const result = extractChangelogContent(content, '1.0.0');
+    const result = extractChangelogContent(content, "1.0.0");
 
-    expect(result).toBe('- Initial release');
+    expect(result).toBe("- Initial release");
   });
 
-  it('returns empty string for missing version', () => {
+  it("returns empty string for missing version", () => {
     const content = `## 1.0.0
 
 - Initial release`;
 
-    const result = extractChangelogContent(content, '2.0.0');
+    const result = extractChangelogContent(content, "2.0.0");
 
-    expect(result).toBe('');
+    expect(result).toBe("");
   });
 
-  it('handles pre-release versions', () => {
+  it("handles pre-release versions", () => {
     const content = `## 1.0.0-beta.1
 
 - Beta features
@@ -124,12 +127,12 @@ describe('extractChangelogContent', () => {
 
 - Alpha features`;
 
-    const result = extractChangelogContent(content, '1.0.0-beta.1');
+    const result = extractChangelogContent(content, "1.0.0-beta.1");
 
-    expect(result).toBe('- Beta features');
+    expect(result).toBe("- Beta features");
   });
 
-  it('handles versions with special regex characters', () => {
+  it("handles versions with special regex characters", () => {
     const content = `## 1.0.0+build.123
 
 - Build metadata
@@ -138,12 +141,12 @@ describe('extractChangelogContent', () => {
 
 - Release`;
 
-    const result = extractChangelogContent(content, '1.0.0+build.123');
+    const result = extractChangelogContent(content, "1.0.0+build.123");
 
-    expect(result).toBe('- Build metadata');
+    expect(result).toBe("- Build metadata");
   });
 
-  it('trims whitespace from extracted content', () => {
+  it("trims whitespace from extracted content", () => {
     const content = `## 1.0.0
 
 
@@ -152,24 +155,24 @@ describe('extractChangelogContent', () => {
 
 ## 0.9.0`;
 
-    const result = extractChangelogContent(content, '1.0.0');
+    const result = extractChangelogContent(content, "1.0.0");
 
-    expect(result).toBe('- Feature with extra whitespace');
+    expect(result).toBe("- Feature with extra whitespace");
   });
 
-  it('handles empty changelog section', () => {
+  it("handles empty changelog section", () => {
     const content = `## 1.0.0
 
 ## 0.9.0
 
 - Previous version`;
 
-    const result = extractChangelogContent(content, '1.0.0');
+    const result = extractChangelogContent(content, "1.0.0");
 
-    expect(result).toBe('');
+    expect(result).toBe("");
   });
 
-  it('handles multiline changelog entries', () => {
+  it("handles multiline changelog entries", () => {
     const content = `## 2.1.0
 
 ### Major Changes
@@ -184,15 +187,15 @@ describe('extractChangelogContent', () => {
 
 ## 2.0.0`;
 
-    const result = extractChangelogContent(content, '2.1.0');
+    const result = extractChangelogContent(content, "2.1.0");
 
-    expect(result).toContain('### Major Changes');
-    expect(result).toContain('Feature 1');
-    expect(result).toContain('Sub-feature A');
-    expect(result).toContain('### Minor Changes');
+    expect(result).toContain("### Major Changes");
+    expect(result).toContain("Feature 1");
+    expect(result).toContain("Sub-feature A");
+    expect(result).toContain("### Minor Changes");
   });
 
-  it('stops at next semver header and ignores other headers', () => {
+  it("stops at next semver header and ignores other headers", () => {
     const content = `## 1.2.0
 
 - Feature A
@@ -206,60 +209,60 @@ describe('extractChangelogContent', () => {
 
 - Old feature`;
 
-    const result = extractChangelogContent(content, '1.2.0');
+    const result = extractChangelogContent(content, "1.2.0");
 
     // Should include "Unreleased" section since it's not a semver header
-    expect(result).toContain('- Feature A');
-    expect(result).toContain('- Feature B');
-    expect(result).toContain('## Unreleased');
-    expect(result).toContain('- Work in progress');
+    expect(result).toContain("- Feature A");
+    expect(result).toContain("- Feature B");
+    expect(result).toContain("## Unreleased");
+    expect(result).toContain("- Work in progress");
     // Should stop at the next semver header (1.1.0)
-    expect(result).not.toContain('## 1.1.0');
-    expect(result).not.toContain('- Old feature');
+    expect(result).not.toContain("## 1.1.0");
+    expect(result).not.toContain("- Old feature");
   });
 });
 
-describe('SEMVER_REGEX', () => {
-  it('matches standard semver', () => {
-    expect(SEMVER_REGEX.test('1.0.0')).toBe(true);
-    expect(SEMVER_REGEX.test('10.20.30')).toBe(true);
+describe("SEMVER_REGEX", () => {
+  it("matches standard semver", () => {
+    expect(SEMVER_REGEX.test("1.0.0")).toBe(true);
+    expect(SEMVER_REGEX.test("10.20.30")).toBe(true);
   });
 
-  it('matches pre-release versions', () => {
-    expect(SEMVER_REGEX.test('1.0.0-alpha')).toBe(true);
-    expect(SEMVER_REGEX.test('1.0.0-beta.1')).toBe(true);
-    expect(SEMVER_REGEX.test('1.0.0-rc.2')).toBe(true);
+  it("matches pre-release versions", () => {
+    expect(SEMVER_REGEX.test("1.0.0-alpha")).toBe(true);
+    expect(SEMVER_REGEX.test("1.0.0-beta.1")).toBe(true);
+    expect(SEMVER_REGEX.test("1.0.0-rc.2")).toBe(true);
   });
 
-  it('matches build metadata', () => {
-    expect(SEMVER_REGEX.test('1.0.0+build')).toBe(true);
-    expect(SEMVER_REGEX.test('1.0.0+20130313144700')).toBe(true);
+  it("matches build metadata", () => {
+    expect(SEMVER_REGEX.test("1.0.0+build")).toBe(true);
+    expect(SEMVER_REGEX.test("1.0.0+20130313144700")).toBe(true);
   });
 
-  it('matches pre-release with build metadata', () => {
-    expect(SEMVER_REGEX.test('1.0.0-beta.1+build.123')).toBe(true);
+  it("matches pre-release with build metadata", () => {
+    expect(SEMVER_REGEX.test("1.0.0-beta.1+build.123")).toBe(true);
   });
 
-  it('rejects invalid versions', () => {
-    expect(SEMVER_REGEX.test('1.0')).toBe(false);
-    expect(SEMVER_REGEX.test('1')).toBe(false);
-    expect(SEMVER_REGEX.test('v1.0.0')).toBe(false);
-    expect(SEMVER_REGEX.test('1.0.0.0')).toBe(false);
+  it("rejects invalid versions", () => {
+    expect(SEMVER_REGEX.test("1.0")).toBe(false);
+    expect(SEMVER_REGEX.test("1")).toBe(false);
+    expect(SEMVER_REGEX.test("v1.0.0")).toBe(false);
+    expect(SEMVER_REGEX.test("1.0.0.0")).toBe(false);
   });
 });
 
-describe('PACKAGE_NAME_REGEX', () => {
-  it('matches valid scoped packages', () => {
-    expect(PACKAGE_NAME_REGEX.test('@robeasthope/markdown')).toBe(true);
-    expect(PACKAGE_NAME_REGEX.test('@robeasthope/ui')).toBe(true);
-    expect(PACKAGE_NAME_REGEX.test('@robeasthope/my-package')).toBe(true);
+describe("PACKAGE_NAME_REGEX", () => {
+  it("matches valid scoped packages", () => {
+    expect(PACKAGE_NAME_REGEX.test("@robeasthope/markdown")).toBe(true);
+    expect(PACKAGE_NAME_REGEX.test("@robeasthope/ui")).toBe(true);
+    expect(PACKAGE_NAME_REGEX.test("@robeasthope/my-package")).toBe(true);
   });
 
-  it('rejects invalid package names', () => {
-    expect(PACKAGE_NAME_REGEX.test('protomolecule/markdown')).toBe(false); // No @
-    expect(PACKAGE_NAME_REGEX.test('@robeasthope')).toBe(false); // No package name
-    expect(PACKAGE_NAME_REGEX.test('@Hecate/markdown')).toBe(false); // Uppercase
-    expect(PACKAGE_NAME_REGEX.test('@robeasthope/Mark_down')).toBe(false); // Underscore
-    expect(PACKAGE_NAME_REGEX.test('@robeasthope/mark down')).toBe(false); // Space
+  it("rejects invalid package names", () => {
+    expect(PACKAGE_NAME_REGEX.test("protomolecule/markdown")).toBe(false); // No @
+    expect(PACKAGE_NAME_REGEX.test("@robeasthope")).toBe(false); // No package name
+    expect(PACKAGE_NAME_REGEX.test("@Hecate/markdown")).toBe(false); // Uppercase
+    expect(PACKAGE_NAME_REGEX.test("@robeasthope/Mark_down")).toBe(false); // Underscore
+    expect(PACKAGE_NAME_REGEX.test("@robeasthope/mark down")).toBe(false); // Space
   });
 });

--- a/.github/scripts/create-releases.ts
+++ b/.github/scripts/create-releases.ts
@@ -21,10 +21,15 @@
  *   1: Error (invalid input, release creation failed, etc.)
  */
 
-import { execSync } from 'node:child_process';
-import { readFileSync, existsSync, appendFileSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { execSync } from "node:child_process";
+import {
+  readFileSync,
+  existsSync,
+  appendFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 export interface Package {
   name: string;
@@ -55,7 +60,7 @@ function addToSummary(text: string): void {
  */
 function releaseExists(tag: string): boolean {
   try {
-    execSync(`gh release view "${tag}"`, { stdio: 'ignore' });
+    execSync(`gh release view "${tag}"`, { stdio: "ignore" });
     return true;
   } catch {
     return false;
@@ -67,12 +72,12 @@ function releaseExists(tag: string): boolean {
  * Pure function - easily testable
  */
 export function getChangelogPaths(packageName: string): string[] {
-  if (packageName === '@robeasthope/infrastructure') {
-    return ['infrastructure/CHANGELOG.md'];
+  if (packageName === "@protomolecule/infrastructure") {
+    return ["infrastructure/CHANGELOG.md"];
   }
 
   // Extract package name without scope
-  const pkgName = packageName.replace('@robeasthope/', '');
+  const pkgName = packageName.replace("@robeasthope/", "");
 
   // Try apps/ first, then packages/
   return [`apps/${pkgName}/CHANGELOG.md`, `packages/${pkgName}/CHANGELOG.md`];
@@ -84,7 +89,7 @@ export function getChangelogPaths(packageName: string): string[] {
  */
 export function findChangelogPath(
   packageName: string,
-  fileExists: FileExistsFn
+  fileExists: FileExistsFn,
 ): string | null {
   const paths = getChangelogPaths(packageName);
 
@@ -103,21 +108,21 @@ export function findChangelogPath(
  */
 export function extractChangelogContent(
   content: string,
-  version: string
+  version: string,
 ): string {
-  const lines = content.split('\n');
+  const lines = content.split("\n");
 
   // No need to escape - we're doing literal string matching with startsWith
   const versionHeader = `## ${version}`;
 
   // Find the start of this version section
   const startIndex = lines.findIndex((line) => line.startsWith(versionHeader));
-  if (startIndex === -1) return '';
+  if (startIndex === -1) return "";
 
   // Find the end (next version header or end of file)
   // Match full semver pattern: ## 1.2.3 (not ## Unreleased or other headers)
   const endIndex = lines.findIndex(
-    (line, idx) => idx > startIndex && line.match(/^## \d+\.\d+\.\d+/)
+    (line, idx) => idx > startIndex && line.match(/^## \d+\.\d+\.\d+/),
   );
 
   // Extract content between headers (excluding the header itself)
@@ -126,27 +131,26 @@ export function extractChangelogContent(
       ? lines.slice(startIndex + 1)
       : lines.slice(startIndex + 1, endIndex);
 
-  return changelogLines.join('\n').trim();
+  return changelogLines.join("\n").trim();
 }
 
 /**
  * Creates a GitHub release
  */
-function createRelease(
-  tag: string,
-  changelog: string,
-  version: string
-): void {
+function createRelease(tag: string, changelog: string, version: string): void {
   const notes = changelog || `Release ${version}`;
 
   // Write notes to temporary file to prevent command injection
   const notesFile = join(tmpdir(), `release-notes-${Date.now()}.md`);
-  writeFileSync(notesFile, notes, 'utf8');
+  writeFileSync(notesFile, notes, "utf8");
 
   try {
-    execSync(`gh release create "${tag}" --title "${tag}" --notes-file "${notesFile}" --target main`, {
-      stdio: 'inherit'
-    });
+    execSync(
+      `gh release create "${tag}" --title "${tag}" --notes-file "${notesFile}" --target main`,
+      {
+        stdio: "inherit",
+      },
+    );
   } catch (error) {
     console.error(`❌ ERROR: Failed to create release for ${tag}`);
     throw error;
@@ -159,9 +163,9 @@ function createRelease(
 function createReleases(): void {
   // Validate arguments
   if (process.argv.length < 3) {
-    console.error('❌ ERROR: Missing required argument');
-    console.error('Usage: tsx create-releases.ts <repository>');
-    console.error('Environment variable PUBLISHED_PACKAGES must be set');
+    console.error("❌ ERROR: Missing required argument");
+    console.error("Usage: tsx create-releases.ts <repository>");
+    console.error("Environment variable PUBLISHED_PACKAGES must be set");
     process.exit(1);
   }
 
@@ -170,7 +174,7 @@ function createReleases(): void {
   // Get published packages from environment variable (avoids shell quoting issues with JSON)
   const publishedJson = process.env.PUBLISHED_PACKAGES;
   if (!publishedJson) {
-    console.error('❌ ERROR: PUBLISHED_PACKAGES environment variable not set');
+    console.error("❌ ERROR: PUBLISHED_PACKAGES environment variable not set");
     process.exit(1);
   }
 
@@ -179,17 +183,19 @@ function createReleases(): void {
   try {
     packages = JSON.parse(publishedJson) as Package[];
   } catch (error) {
-    console.error('❌ ERROR: Invalid JSON in PUBLISHED_PACKAGES environment variable');
+    console.error(
+      "❌ ERROR: Invalid JSON in PUBLISHED_PACKAGES environment variable",
+    );
     console.error(`Received: ${publishedJson}`);
     process.exit(1);
   }
 
-  console.log('Creating releases for published packages...');
+  console.log("Creating releases for published packages...");
 
   // Initialize summary table
-  addToSummary('## 🚀 Release Summary\n\n');
-  addToSummary('| Package | Version | Tag | Release |\n');
-  addToSummary('|---------|---------|-----|---------|\\n');
+  addToSummary("## 🚀 Release Summary\n\n");
+  addToSummary("| Package | Version | Tag | Release |\n");
+  addToSummary("|---------|---------|-----|---------|\\n");
 
   for (const pkg of packages) {
     const { name, version } = pkg;
@@ -198,7 +204,7 @@ function createReleases(): void {
     if (!PACKAGE_NAME_REGEX.test(name)) {
       console.error(`❌ ERROR: Invalid package name format: ${name}`);
       console.error(
-        'Expected format: @scope/package-name (lowercase, alphanumeric, hyphens only)'
+        "Expected format: @scope/package-name (lowercase, alphanumeric, hyphens only)",
       );
       process.exit(1);
     }
@@ -207,7 +213,7 @@ function createReleases(): void {
     if (!SEMVER_REGEX.test(version)) {
       console.error(`❌ ERROR: Invalid version format: ${version}`);
       console.error(
-        'Expected semver format (e.g., 1.0.0, 1.0.0-beta.1, 1.0.0+build.123)'
+        "Expected semver format (e.g., 1.0.0, 1.0.0-beta.1, 1.0.0+build.123)",
       );
       process.exit(1);
     }
@@ -218,20 +224,22 @@ function createReleases(): void {
     // Check if release already exists (idempotency)
     if (releaseExists(tag)) {
       console.log(`⚠️  Release ${tag} already exists, skipping creation`);
-      console.log(`   Existing release: https://github.com/${repository}/releases/tag/${tag}`);
+      console.log(
+        `   Existing release: https://github.com/${repository}/releases/tag/${tag}`,
+      );
 
       const releaseUrl = `https://github.com/${repository}/releases/tag/${tag}`;
       addToSummary(
-        `| ${name} | ${version} | \`${tag}\` | [View Release](${releaseUrl}) |\\n`
+        `| ${name} | ${version} | \`${tag}\` | [View Release](${releaseUrl}) |\\n`,
       );
       continue;
     }
 
     // Extract changelog
     const changelogPath = findChangelogPath(name, existsSync);
-    let changelog = '';
+    let changelog = "";
     if (changelogPath && existsSync(changelogPath)) {
-      const content = readFileSync(changelogPath, 'utf8');
+      const content = readFileSync(changelogPath, "utf8");
       changelog = extractChangelogContent(content, version);
     }
 
@@ -242,7 +250,7 @@ function createReleases(): void {
 
       const releaseUrl = `https://github.com/${repository}/releases/tag/${tag}`;
       addToSummary(
-        `| ${name} | ${version} | \`${tag}\` | [View Release](${releaseUrl}) |\\n`
+        `| ${name} | ${version} | \`${tag}\` | [View Release](${releaseUrl}) |\\n`,
       );
     } catch (error) {
       process.exit(1);
@@ -252,7 +260,7 @@ function createReleases(): void {
   // Add summary footer
   addToSummary(`\n**Total packages released:** ${packages.length}\n`);
 
-  console.log('🎉 All package releases created successfully');
+  console.log("🎉 All package releases created successfully");
 }
 
 // Run the script only if executed directly (not imported)
@@ -261,7 +269,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     createReleases();
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
-    console.error('❌ ERROR: Unexpected error:', errorMessage);
+    console.error("❌ ERROR: Unexpected error:", errorMessage);
     process.exit(1);
   }
 }

--- a/.github/scripts/detect-published.test.ts
+++ b/.github/scripts/detect-published.test.ts
@@ -1,250 +1,247 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from "vitest";
 import {
   filterChangelogFiles,
   validatePackageJson,
   parseChangelogs,
   type PackageJson,
   type ReadFileFn,
-  type FileExistsFn
-} from './detect-published';
+  type FileExistsFn,
+} from "./detect-published";
 
-describe('filterChangelogFiles', () => {
-  it('filters to only CHANGELOG.md files', () => {
+describe("filterChangelogFiles", () => {
+  it("filters to only CHANGELOG.md files", () => {
     const files = [
-      'apps/markdown/CHANGELOG.md',
-      'apps/markdown/package.json',
-      'packages/ui/CHANGELOG.md',
-      'README.md',
-      'infrastructure/CHANGELOG.md'
+      "apps/markdown/CHANGELOG.md",
+      "apps/markdown/package.json",
+      "packages/ui/CHANGELOG.md",
+      "README.md",
+      "infrastructure/CHANGELOG.md",
     ];
 
     const result = filterChangelogFiles(files);
 
     expect(result).toEqual([
-      'apps/markdown/CHANGELOG.md',
-      'packages/ui/CHANGELOG.md',
-      'infrastructure/CHANGELOG.md'
+      "apps/markdown/CHANGELOG.md",
+      "packages/ui/CHANGELOG.md",
+      "infrastructure/CHANGELOG.md",
     ]);
   });
 
-  it('returns empty array when no CHANGELOG files', () => {
-    const files = ['README.md', 'package.json', 'src/index.ts'];
+  it("returns empty array when no CHANGELOG files", () => {
+    const files = ["README.md", "package.json", "src/index.ts"];
 
     const result = filterChangelogFiles(files);
 
     expect(result).toEqual([]);
   });
 
-  it('handles empty array', () => {
+  it("handles empty array", () => {
     const result = filterChangelogFiles([]);
 
     expect(result).toEqual([]);
   });
 
-  it('filters case-insensitively', () => {
+  it("filters case-insensitively", () => {
     const files = [
-      'apps/markdown/CHANGELOG.md',
-      'packages/ui/changelog.md',
-      'infrastructure/Changelog.md',
-      'apps/other/ChangeLog.MD'
+      "apps/markdown/CHANGELOG.md",
+      "packages/ui/changelog.md",
+      "infrastructure/Changelog.md",
+      "apps/other/ChangeLog.MD",
     ];
 
     const result = filterChangelogFiles(files);
 
     expect(result).toEqual([
-      'apps/markdown/CHANGELOG.md',
-      'packages/ui/changelog.md',
-      'infrastructure/Changelog.md',
-      'apps/other/ChangeLog.MD'
+      "apps/markdown/CHANGELOG.md",
+      "packages/ui/changelog.md",
+      "infrastructure/Changelog.md",
+      "apps/other/ChangeLog.MD",
     ]);
   });
 });
 
-describe('validatePackageJson', () => {
-  it('validates package with name and version', () => {
+describe("validatePackageJson", () => {
+  it("validates package with name and version", () => {
     const packageJson: PackageJson = {
-      name: '@robeasthope/markdown',
-      version: '1.0.0'
+      name: "@robeasthope/markdown",
+      version: "1.0.0",
     };
 
     expect(() => validatePackageJson(packageJson)).not.toThrow();
   });
 
-  it('throws when name is missing', () => {
+  it("throws when name is missing", () => {
     const packageJson: PackageJson = {
-      version: '1.0.0'
+      version: "1.0.0",
     };
 
     expect(() => validatePackageJson(packageJson)).toThrow(
-      'Invalid package.json: missing name or version'
+      "Invalid package.json: missing name or version",
     );
   });
 
-  it('throws when version is missing', () => {
+  it("throws when version is missing", () => {
     const packageJson: PackageJson = {
-      name: '@robeasthope/markdown'
+      name: "@robeasthope/markdown",
     };
 
     expect(() => validatePackageJson(packageJson)).toThrow(
-      'Invalid package.json: missing name or version'
+      "Invalid package.json: missing name or version",
     );
   });
 
-  it('throws when both name and version are missing', () => {
+  it("throws when both name and version are missing", () => {
     const packageJson: PackageJson = {};
 
     expect(() => validatePackageJson(packageJson)).toThrow(
-      'Invalid package.json: missing name or version'
+      "Invalid package.json: missing name or version",
     );
   });
 
-  it('throws when name is not a string', () => {
+  it("throws when name is not a string", () => {
     const packageJson = {
       name: 123,
-      version: '1.0.0'
+      version: "1.0.0",
     } as unknown as PackageJson;
 
     expect(() => validatePackageJson(packageJson)).toThrow(
-      'Invalid package.json: name must be a string, got number'
+      "Invalid package.json: name must be a string, got number",
     );
   });
 
-  it('throws when version is not a string', () => {
+  it("throws when version is not a string", () => {
     const packageJson = {
-      name: '@robeasthope/markdown',
-      version: { major: 1, minor: 0, patch: 0 }
+      name: "@robeasthope/markdown",
+      version: { major: 1, minor: 0, patch: 0 },
     } as unknown as PackageJson;
 
     expect(() => validatePackageJson(packageJson)).toThrow(
-      'Invalid package.json: version must be a string, got object'
+      "Invalid package.json: version must be a string, got object",
     );
   });
 
-  it('throws when both name and version are wrong types', () => {
+  it("throws when both name and version are wrong types", () => {
     const packageJson = {
-      name: ['@robeasthope/markdown'],
-      version: 1.0
+      name: ["@robeasthope/markdown"],
+      version: 1.0,
     } as unknown as PackageJson;
 
     expect(() => validatePackageJson(packageJson)).toThrow(
-      'Invalid package.json: name must be a string, got object'
+      "Invalid package.json: name must be a string, got object",
     );
   });
 });
 
-describe('parseChangelogs', () => {
-  it('extracts package info from CHANGELOG changes', () => {
-    const files = ['apps/markdown/CHANGELOG.md'];
+describe("parseChangelogs", () => {
+  it("extracts package info from CHANGELOG changes", () => {
+    const files = ["apps/markdown/CHANGELOG.md"];
     const mockRead: ReadFileFn = vi.fn((path: string) => {
-      if (path === 'apps/markdown/package.json') {
+      if (path === "apps/markdown/package.json") {
         return JSON.stringify({
-          name: '@robeasthope/markdown',
-          version: '1.0.0'
+          name: "@robeasthope/markdown",
+          version: "1.0.0",
         });
       }
-      return '';
+      return "";
     });
     const mockExists: FileExistsFn = vi.fn(() => true);
 
     const result = parseChangelogs(files, mockRead, mockExists);
 
     expect(result).toEqual([
-      { name: '@robeasthope/markdown', version: '1.0.0' }
+      { name: "@robeasthope/markdown", version: "1.0.0" },
     ]);
-    expect(mockRead).toHaveBeenCalledWith('apps/markdown/package.json');
-    expect(mockExists).toHaveBeenCalledWith('apps/markdown/package.json');
+    expect(mockRead).toHaveBeenCalledWith("apps/markdown/package.json");
+    expect(mockExists).toHaveBeenCalledWith("apps/markdown/package.json");
   });
 
-  it('handles multiple packages', () => {
+  it("handles multiple packages", () => {
+    const files = ["apps/markdown/CHANGELOG.md", "packages/ui/CHANGELOG.md"];
+    const mockRead: ReadFileFn = vi.fn((path: string) => {
+      if (path === "apps/markdown/package.json") {
+        return JSON.stringify({
+          name: "@robeasthope/markdown",
+          version: "1.0.0",
+        });
+      }
+      if (path === "packages/ui/package.json") {
+        return JSON.stringify({
+          name: "@robeasthope/ui",
+          version: "2.1.0",
+        });
+      }
+      return "";
+    });
+    const mockExists: FileExistsFn = vi.fn(() => true);
+
+    const result = parseChangelogs(files, mockRead, mockExists);
+
+    expect(result).toEqual([
+      { name: "@robeasthope/markdown", version: "1.0.0" },
+      { name: "@robeasthope/ui", version: "2.1.0" },
+    ]);
+  });
+
+  it("skips CHANGELOG without package.json", () => {
     const files = [
-      'apps/markdown/CHANGELOG.md',
-      'packages/ui/CHANGELOG.md'
+      "apps/markdown/CHANGELOG.md",
+      "docs/CHANGELOG.md", // No package.json here
     ];
     const mockRead: ReadFileFn = vi.fn((path: string) => {
-      if (path === 'apps/markdown/package.json') {
+      if (path === "apps/markdown/package.json") {
         return JSON.stringify({
-          name: '@robeasthope/markdown',
-          version: '1.0.0'
+          name: "@robeasthope/markdown",
+          version: "1.0.0",
         });
       }
-      if (path === 'packages/ui/package.json') {
-        return JSON.stringify({
-          name: '@robeasthope/ui',
-          version: '2.1.0'
-        });
-      }
-      return '';
+      return "";
     });
-    const mockExists: FileExistsFn = vi.fn(() => true);
-
-    const result = parseChangelogs(files, mockRead, mockExists);
-
-    expect(result).toEqual([
-      { name: '@robeasthope/markdown', version: '1.0.0' },
-      { name: '@robeasthope/ui', version: '2.1.0' }
-    ]);
-  });
-
-  it('skips CHANGELOG without package.json', () => {
-    const files = [
-      'apps/markdown/CHANGELOG.md',
-      'docs/CHANGELOG.md' // No package.json here
-    ];
-    const mockRead: ReadFileFn = vi.fn((path: string) => {
-      if (path === 'apps/markdown/package.json') {
-        return JSON.stringify({
-          name: '@robeasthope/markdown',
-          version: '1.0.0'
-        });
-      }
-      return '';
-    });
-    const mockExists: FileExistsFn = vi.fn((path: string) =>
-      path === 'apps/markdown/package.json'
+    const mockExists: FileExistsFn = vi.fn(
+      (path: string) => path === "apps/markdown/package.json",
     );
 
     const result = parseChangelogs(files, mockRead, mockExists);
 
     expect(result).toEqual([
-      { name: '@robeasthope/markdown', version: '1.0.0' }
+      { name: "@robeasthope/markdown", version: "1.0.0" },
     ]);
   });
 
-  it('throws on invalid JSON', () => {
-    const files = ['apps/markdown/CHANGELOG.md'];
-    const mockRead: ReadFileFn = vi.fn(() => 'invalid json{');
+  it("throws on invalid JSON", () => {
+    const files = ["apps/markdown/CHANGELOG.md"];
+    const mockRead: ReadFileFn = vi.fn(() => "invalid json{");
     const mockExists: FileExistsFn = vi.fn(() => true);
 
     expect(() => parseChangelogs(files, mockRead, mockExists)).toThrow(
-      /Invalid JSON in apps\/markdown\/package\.json/
+      /Invalid JSON in apps\/markdown\/package\.json/,
     );
   });
 
-  it('throws on missing name field', () => {
-    const files = ['apps/markdown/CHANGELOG.md'];
+  it("throws on missing name field", () => {
+    const files = ["apps/markdown/CHANGELOG.md"];
     const mockRead: ReadFileFn = vi.fn(() =>
-      JSON.stringify({ version: '1.0.0' })
+      JSON.stringify({ version: "1.0.0" }),
     );
     const mockExists: FileExistsFn = vi.fn(() => true);
 
     expect(() => parseChangelogs(files, mockRead, mockExists)).toThrow(
-      /Invalid JSON in apps\/markdown\/package\.json/
+      /Invalid JSON in apps\/markdown\/package\.json/,
     );
   });
 
-  it('throws on missing version field', () => {
-    const files = ['apps/markdown/CHANGELOG.md'];
+  it("throws on missing version field", () => {
+    const files = ["apps/markdown/CHANGELOG.md"];
     const mockRead: ReadFileFn = vi.fn(() =>
-      JSON.stringify({ name: '@robeasthope/markdown' })
+      JSON.stringify({ name: "@robeasthope/markdown" }),
     );
     const mockExists: FileExistsFn = vi.fn(() => true);
 
     expect(() => parseChangelogs(files, mockRead, mockExists)).toThrow(
-      /Invalid JSON in apps\/markdown\/package\.json/
+      /Invalid JSON in apps\/markdown\/package\.json/,
     );
   });
 
-  it('returns empty array for empty input', () => {
+  it("returns empty array for empty input", () => {
     const mockRead: ReadFileFn = vi.fn();
     const mockExists: FileExistsFn = vi.fn();
 
@@ -255,20 +252,20 @@ describe('parseChangelogs', () => {
     expect(mockExists).not.toHaveBeenCalled();
   });
 
-  it('handles infrastructure package specially', () => {
-    const files = ['infrastructure/CHANGELOG.md'];
+  it("handles infrastructure package specially", () => {
+    const files = ["infrastructure/CHANGELOG.md"];
     const mockRead: ReadFileFn = vi.fn(() =>
       JSON.stringify({
-        name: '@robeasthope/infrastructure',
-        version: '0.1.0'
-      })
+        name: "@protomolecule/infrastructure",
+        version: "0.1.0",
+      }),
     );
     const mockExists: FileExistsFn = vi.fn(() => true);
 
     const result = parseChangelogs(files, mockRead, mockExists);
 
     expect(result).toEqual([
-      { name: '@robeasthope/infrastructure', version: '0.1.0' }
+      { name: "@protomolecule/infrastructure", version: "0.1.0" },
     ]);
   });
 });

--- a/.github/scripts/generate-summary.test.ts
+++ b/.github/scripts/generate-summary.test.ts
@@ -1,137 +1,141 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from "vitest";
 import {
   determineSummaryDepth,
   formatPackageSummary,
   generateFallbackSummary,
   validateAIResponse,
   type Package,
-  type BumpType
-} from './generate-summary';
+  type BumpType,
+} from "./generate-summary";
 
-describe('determineSummaryDepth', () => {
-  it('returns brief for single package patch', () => {
-    const result = determineSummaryDepth('patch', 1);
+describe("determineSummaryDepth", () => {
+  it("returns brief for single package patch", () => {
+    const result = determineSummaryDepth("patch", 1);
 
-    expect(result).toBe('brief');
+    expect(result).toBe("brief");
   });
 
-  it('returns brief for single package minor', () => {
-    const result = determineSummaryDepth('minor', 1);
+  it("returns brief for single package minor", () => {
+    const result = determineSummaryDepth("minor", 1);
 
-    expect(result).toBe('brief');
+    expect(result).toBe("brief");
   });
 
-  it('returns detailed for single package major', () => {
-    const result = determineSummaryDepth('major', 1);
+  it("returns detailed for single package major", () => {
+    const result = determineSummaryDepth("major", 1);
 
-    expect(result).toBe('detailed');
+    expect(result).toBe("detailed");
   });
 
-  it('returns comprehensive for major with 2 packages', () => {
-    const result = determineSummaryDepth('major', 2);
+  it("returns comprehensive for major with 2 packages", () => {
+    const result = determineSummaryDepth("major", 2);
 
-    expect(result).toBe('comprehensive');
+    expect(result).toBe("comprehensive");
   });
 
-  it('returns comprehensive for major with 3+ packages', () => {
-    const result = determineSummaryDepth('major', 5);
+  it("returns comprehensive for major with 3+ packages", () => {
+    const result = determineSummaryDepth("major", 5);
 
-    expect(result).toBe('comprehensive');
+    expect(result).toBe("comprehensive");
   });
 
-  it('returns detailed for 3+ packages with minor bump', () => {
-    const result = determineSummaryDepth('minor', 3);
+  it("returns detailed for 3+ packages with minor bump", () => {
+    const result = determineSummaryDepth("minor", 3);
 
-    expect(result).toBe('detailed');
+    expect(result).toBe("detailed");
   });
 
-  it('returns detailed for 3+ packages with patch bump', () => {
-    const result = determineSummaryDepth('patch', 3);
+  it("returns detailed for 3+ packages with patch bump", () => {
+    const result = determineSummaryDepth("patch", 3);
 
-    expect(result).toBe('detailed');
+    expect(result).toBe("detailed");
   });
 
-  it('returns brief for 2 packages with minor bump', () => {
-    const result = determineSummaryDepth('minor', 2);
+  it("returns brief for 2 packages with minor bump", () => {
+    const result = determineSummaryDepth("minor", 2);
 
-    expect(result).toBe('brief');
+    expect(result).toBe("brief");
   });
 });
 
-describe('formatPackageSummary', () => {
-  it('formats single package', () => {
-    const packages: Package[] = [{ name: '@robeasthope/markdown', version: '1.0.0' }];
+describe("formatPackageSummary", () => {
+  it("formats single package", () => {
+    const packages: Package[] = [
+      { name: "@robeasthope/markdown", version: "1.0.0" },
+    ];
 
     const result = formatPackageSummary(packages);
 
-    expect(result).toBe('@robeasthope/markdown@1.0.0');
+    expect(result).toBe("@robeasthope/markdown@1.0.0");
   });
 
-  it('formats multiple packages with newlines', () => {
+  it("formats multiple packages with newlines", () => {
     const packages: Package[] = [
-      { name: '@robeasthope/markdown', version: '1.0.0' },
-      { name: '@robeasthope/ui', version: '2.1.0' },
-      { name: '@robeasthope/infrastructure', version: '0.3.0' }
+      { name: "@robeasthope/markdown", version: "1.0.0" },
+      { name: "@robeasthope/ui", version: "2.1.0" },
+      { name: "@protomolecule/infrastructure", version: "0.3.0" },
     ];
 
     const result = formatPackageSummary(packages);
 
     expect(result).toBe(
-      '@robeasthope/markdown@1.0.0\n@robeasthope/ui@2.1.0\n@robeasthope/infrastructure@0.3.0'
+      "@robeasthope/markdown@1.0.0\n@robeasthope/ui@2.1.0\n@protomolecule/infrastructure@0.3.0",
     );
   });
 
-  it('handles empty array', () => {
+  it("handles empty array", () => {
     const result = formatPackageSummary([]);
 
-    expect(result).toBe('');
+    expect(result).toBe("");
   });
 
-  it('handles pre-release versions', () => {
+  it("handles pre-release versions", () => {
     const packages: Package[] = [
-      { name: '@robeasthope/markdown', version: '1.0.0-beta.1' }
+      { name: "@robeasthope/markdown", version: "1.0.0-beta.1" },
     ];
 
     const result = formatPackageSummary(packages);
 
-    expect(result).toBe('@robeasthope/markdown@1.0.0-beta.1');
+    expect(result).toBe("@robeasthope/markdown@1.0.0-beta.1");
   });
 });
 
-describe('generateFallbackSummary', () => {
-  it('generates template for single package', () => {
-    const packages: Package[] = [{ name: '@robeasthope/markdown', version: '1.0.0' }];
-
-    const result = generateFallbackSummary(packages);
-
-    expect(result).toContain('## Workspace Updates');
-    expect(result).toContain('* @robeasthope/markdown@1.0.0');
-    expect(result).toContain('AI summary unavailable');
-    expect(result).toContain('see individual package changelogs');
-  });
-
-  it('generates template for multiple packages', () => {
+describe("generateFallbackSummary", () => {
+  it("generates template for single package", () => {
     const packages: Package[] = [
-      { name: '@robeasthope/markdown', version: '1.0.0' },
-      { name: '@robeasthope/ui', version: '2.1.0' }
+      { name: "@robeasthope/markdown", version: "1.0.0" },
     ];
 
     const result = generateFallbackSummary(packages);
 
-    expect(result).toContain('* @robeasthope/markdown@1.0.0');
-    expect(result).toContain('* @robeasthope/ui@2.1.0');
+    expect(result).toContain("## Workspace Updates");
+    expect(result).toContain("* @robeasthope/markdown@1.0.0");
+    expect(result).toContain("AI summary unavailable");
+    expect(result).toContain("see individual package changelogs");
   });
 
-  it('handles empty packages array', () => {
+  it("generates template for multiple packages", () => {
+    const packages: Package[] = [
+      { name: "@robeasthope/markdown", version: "1.0.0" },
+      { name: "@robeasthope/ui", version: "2.1.0" },
+    ];
+
+    const result = generateFallbackSummary(packages);
+
+    expect(result).toContain("* @robeasthope/markdown@1.0.0");
+    expect(result).toContain("* @robeasthope/ui@2.1.0");
+  });
+
+  it("handles empty packages array", () => {
     const result = generateFallbackSummary([]);
 
-    expect(result).toContain('## Workspace Updates');
-    expect(result).toContain('AI summary unavailable');
+    expect(result).toContain("## Workspace Updates");
+    expect(result).toContain("AI summary unavailable");
   });
 
-  it('formats with markdown list items', () => {
+  it("formats with markdown list items", () => {
     const packages: Package[] = [
-      { name: '@robeasthope/test', version: '1.0.0' }
+      { name: "@robeasthope/test", version: "1.0.0" },
     ];
 
     const result = generateFallbackSummary(packages);
@@ -141,83 +145,84 @@ describe('generateFallbackSummary', () => {
   });
 });
 
-describe('validateAIResponse', () => {
-  it('validates valid string response', () => {
-    const content = 'This is a valid AI response with sufficient length.';
+describe("validateAIResponse", () => {
+  it("validates valid string response", () => {
+    const content = "This is a valid AI response with sufficient length.";
 
     const result = validateAIResponse(content);
 
     expect(result).toBe(content);
   });
 
-  it('throws on empty string', () => {
-    expect(() => validateAIResponse('')).toThrow(
-      'AI response is empty or not a string'
+  it("throws on empty string", () => {
+    expect(() => validateAIResponse("")).toThrow(
+      "AI response is empty or not a string",
     );
   });
 
-  it('throws on null', () => {
+  it("throws on null", () => {
     expect(() => validateAIResponse(null)).toThrow(
-      'AI response is empty or not a string'
+      "AI response is empty or not a string",
     );
   });
 
-  it('throws on undefined', () => {
+  it("throws on undefined", () => {
     expect(() => validateAIResponse(undefined)).toThrow(
-      'AI response is empty or not a string'
+      "AI response is empty or not a string",
     );
   });
 
-  it('throws on number', () => {
+  it("throws on number", () => {
     expect(() => validateAIResponse(123)).toThrow(
-      'AI response is empty or not a string'
+      "AI response is empty or not a string",
     );
   });
 
-  it('throws on object', () => {
-    expect(() => validateAIResponse({ content: 'test' })).toThrow(
-      'AI response is empty or not a string'
+  it("throws on object", () => {
+    expect(() => validateAIResponse({ content: "test" })).toThrow(
+      "AI response is empty or not a string",
     );
   });
 
-  it('throws on too short response', () => {
-    expect(() => validateAIResponse('short')).toThrow(
-      'AI response too short: 5 characters'
+  it("throws on too short response", () => {
+    expect(() => validateAIResponse("short")).toThrow(
+      "AI response too short: 5 characters",
     );
   });
 
-  it('throws on response at 9 characters (boundary)', () => {
-    expect(() => validateAIResponse('123456789')).toThrow(
-      'AI response too short: 9 characters'
+  it("throws on response at 9 characters (boundary)", () => {
+    expect(() => validateAIResponse("123456789")).toThrow(
+      "AI response too short: 9 characters",
     );
   });
 
-  it('accepts response at 10 characters (boundary)', () => {
-    const content = '1234567890';
+  it("accepts response at 10 characters (boundary)", () => {
+    const content = "1234567890";
 
     const result = validateAIResponse(content);
 
     expect(result).toBe(content);
   });
 
-  it('throws on too long response', () => {
-    const content = 'x'.repeat(5001);
+  it("throws on too long response", () => {
+    const content = "x".repeat(5001);
 
     expect(() => validateAIResponse(content)).toThrow(
-      'AI response too long: 5001 characters'
+      "AI response too long: 5001 characters",
     );
   });
 
-  it('accepts response at 5000 characters (boundary)', () => {
-    const content = 'x'.repeat(5000);
+  it("accepts response at 5000 characters (boundary)", () => {
+    const content = "x".repeat(5000);
 
     const result = validateAIResponse(content);
 
     expect(result).toBe(content);
   });
 
-  it('accepts typical AI response length', () => {
-    const content = '## Summary\n\nThis release includes updates to the markdown package with improved performance and new features.\n\n## Highlights\n* ✨ New feature\n* ⚡ Performance improvements';
+  it("accepts typical AI response length", () => {
+    const content =
+      "## Summary\n\nThis release includes updates to the markdown package with improved performance and new features.\n\n## Highlights\n* ✨ New feature\n* ⚡ Performance improvements";
 
     const result = validateAIResponse(content);
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -107,7 +107,7 @@ do
     echo "${GREEN}✅ Package changes are documentation-only - changeset not required${NC}"
   fi
 
-  # Check for infrastructure changes that should be tracked in @robeasthope/infrastructure
+  # Check for infrastructure changes that should be tracked in @protomolecule/infrastructure
   # These are critical files that affect the build system, CI/CD, or developer workflow
   INFRA_FILES=$(git diff --name-only "$range" 2>/dev/null | grep -E "^(\.github/workflows/|\.github/scripts/|\.github/actions/|\.husky/|turbo\.json$|pnpm-workspace\.yaml$|eslint\.config\.ts$|tsconfig\.json$|\.prettierrc\.json$|\.markdownlint-cli2\.jsonc$|\.yamllint\.yml$|package\.json$|\.actrc$|\.actrc\.example$)" || true)
 
@@ -120,15 +120,15 @@ do
     echo "$INFRA_FILES" | sed 's/^/  - /'
     echo ""
 
-    # Check for changeset affecting @robeasthope/infrastructure
+    # Check for changeset affecting @protomolecule/infrastructure
     # grep -l returns files containing the pattern, xargs handles the case when files exist
-    INFRA_CHANGESET=$(ls -A .changeset/*.md 2>/dev/null | grep -v README.md | xargs grep -l '@robeasthope/infrastructure' 2>/dev/null || true)
+    INFRA_CHANGESET=$(ls -A .changeset/*.md 2>/dev/null | grep -v README.md | xargs grep -l '@protomolecule/infrastructure' 2>/dev/null || true)
 
     if [ -z "$INFRA_CHANGESET" ]; then
       echo ""
       echo "${RED}❌ Pre-push check failed!${NC}"
       echo ""
-      echo "You're pushing infrastructure changes without a changeset for ${YELLOW}@robeasthope/infrastructure${NC}."
+      echo "You're pushing infrastructure changes without a changeset for ${YELLOW}@protomolecule/infrastructure${NC}."
       echo ""
       echo "Infrastructure changes need to be tracked in the changelog so we can:"
       echo "  • Document when critical tooling/workflow changes were made"
@@ -137,7 +137,7 @@ do
       echo ""
       echo "To fix this:"
       echo "  1. Run: ${GREEN}pnpm changeset${NC}"
-      echo "  2. Select ${GREEN}@robeasthope/infrastructure${NC} package"
+      echo "  2. Select ${GREEN}@protomolecule/infrastructure${NC} package"
       echo "  3. Choose version bump:"
       echo "     • ${GREEN}patch${NC} - Bug fixes, minor config tweaks"
       echo "     • ${GREEN}minor${NC} - New features, workflow additions"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### Making Code Changes
 
 1. **Package changes** → Create changeset for the specific package (e.g., `@robeasthope/ui`)
-2. **Infrastructure changes** → Create changeset for `@robeasthope/infrastructure`
+2. **Infrastructure changes** → Create changeset for `@protomolecule/infrastructure`
 3. **Documentation only** → No changeset required
 
 ### Example Workflow
@@ -25,7 +25,7 @@ vim .github/workflows/release.yml
 
 # Create infrastructure changeset
 pnpm changeset
-# Select: @robeasthope/infrastructure, patch, "Fix release workflow timing"
+# Select: @protomolecule/infrastructure, patch, "Fix release workflow timing"
 
 # Commit with conventional format
 git commit -m "feat(ui): add loading state to Button component"
@@ -128,12 +128,12 @@ Create a changeset **ONLY** when you modify source code in `packages/*/src/` or 
 
 **DO NOT** create package changesets for infrastructure changes:
 
-- ❌ Root `package.json` script changes → Use `@robeasthope/infrastructure` changeset
-- ❌ `.github/` directory changes (workflows, scripts, actions) → Use `@robeasthope/infrastructure` changeset
-- ❌ Root configuration files (`.prettierrc`, `.eslintrc`, etc.) → Use `@robeasthope/infrastructure` changeset
-- ❌ Build/test tooling configuration at root level → Use `@robeasthope/infrastructure` changeset
-- ❌ CI/CD configuration changes → Use `@robeasthope/infrastructure` changeset
-- ❌ Git hooks or linting configuration → Use `@robeasthope/infrastructure` changeset
+- ❌ Root `package.json` script changes → Use `@protomolecule/infrastructure` changeset
+- ❌ `.github/` directory changes (workflows, scripts, actions) → Use `@protomolecule/infrastructure` changeset
+- ❌ Root configuration files (`.prettierrc`, `.eslintrc`, etc.) → Use `@protomolecule/infrastructure` changeset
+- ❌ Build/test tooling configuration at root level → Use `@protomolecule/infrastructure` changeset
+- ❌ CI/CD configuration changes → Use `@protomolecule/infrastructure` changeset
+- ❌ Git hooks or linting configuration → Use `@protomolecule/infrastructure` changeset
 - ✅ Documentation updates (`*.md` files) → No changeset required
 
 See [Infrastructure Package](#infrastructure-package) for infrastructure changeset guidelines.
@@ -182,7 +182,7 @@ See [Infrastructure Package](#infrastructure-package) for infrastructure changes
 
 **Private packages** (`tsconfig`, `github-rulesets`) still require changesets for version tracking but are not published to NPM.
 
-**When in doubt:** If you're only modifying files at the repository root level or in `.github/`, you should create a changeset for `@robeasthope/infrastructure` instead of a package changeset. See [Infrastructure Package](#infrastructure-package) below.
+**When in doubt:** If you're only modifying files at the repository root level or in `.github/`, you should create a changeset for `@protomolecule/infrastructure` instead of a package changeset. See [Infrastructure Package](#infrastructure-package) below.
 
 ## Monorepo Structure
 
@@ -286,11 +286,11 @@ This is a React component library monorepo built with:
 
 ### Purpose
 
-The `infrastructure/` directory contains a virtual package (`@robeasthope/infrastructure`) for tracking CI/CD, workflow, and tooling changes separate from code packages. It has no actual code - it's purely for version tracking.
+The `infrastructure/` directory contains a virtual package (`@protomolecule/infrastructure`) for tracking CI/CD, workflow, and tooling changes separate from code packages. It has no actual code - it's purely for version tracking.
 
 ### When to Create Infrastructure Changesets
 
-Create changesets for `@robeasthope/infrastructure` when modifying:
+Create changesets for `@protomolecule/infrastructure` when modifying:
 
 **CI/CD & Workflows:**
 
@@ -345,7 +345,7 @@ Runs `lint-staged` to format and lint staged files:
 **Infrastructure Changeset Enforcement:**
 
 - Detects changes to `.github/`, `.husky/`, root configs, and tooling files
-- Requires a changeset for `@robeasthope/infrastructure`
+- Requires a changeset for `@protomolecule/infrastructure`
 - Lists the changed infrastructure files for clarity
 - Provides helpful guidance on creating infrastructure changesets
 

--- a/infrastructure/CHANGELOG.md
+++ b/infrastructure/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @robeasthope/infrastructure
+# @protomolecule/infrastructure
 
 ## 2.0.1
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,4 +1,4 @@
-# @robeasthope/infrastructure
+# @protomolecule/infrastructure
 
 Virtual package for tracking monorepo infrastructure and tooling changes.
 
@@ -8,7 +8,7 @@ This package exists solely to track version history of infrastructure changes th
 
 ## When to Create Changesets for Infrastructure
 
-Create changesets for `@robeasthope/infrastructure` when making changes to:
+Create changesets for `@protomolecule/infrastructure` when making changes to:
 
 ### CI/CD & Workflows
 
@@ -69,7 +69,7 @@ Create changesets for `@robeasthope/infrastructure` when making changes to:
 
 ```bash
 pnpm changeset
-# When prompted, select @robeasthope/infrastructure
+# When prompted, select @protomolecule/infrastructure
 # Choose patch/minor/major based on change significance
 ```
 
@@ -79,7 +79,7 @@ Create `.changeset/your-change-name.md`:
 
 ```markdown
 ---
-"@robeasthope/infrastructure": patch
+"@protomolecule/infrastructure": patch
 ---
 
 Description of infrastructure change
@@ -114,7 +114,7 @@ Description of infrastructure change
 
 ```markdown
 ---
-"@robeasthope/infrastructure": patch
+"@protomolecule/infrastructure": patch
 ---
 
 Fix: GitHub Actions workflow now correctly handles release failures
@@ -124,7 +124,7 @@ Fix: GitHub Actions workflow now correctly handles release failures
 
 ```markdown
 ---
-"@robeasthope/infrastructure": minor
+"@protomolecule/infrastructure": minor
 ---
 
 Add: YAML linting with yamllint and actionlint in CI
@@ -134,7 +134,7 @@ Add: YAML linting with yamllint and actionlint in CI
 
 ```markdown
 ---
-"@robeasthope/infrastructure": major
+"@protomolecule/infrastructure": major
 ---
 
 BREAKING: Upgrade to Node 22, requires developers to update local environment

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@robeasthope/infrastructure",
+  "name": "@protomolecule/infrastructure",
   "version": "2.0.1",
   "private": true,
   "description": "Virtual package for tracking monorepo infrastructure and tooling changes"


### PR DESCRIPTION
## Summary

Renames the infrastructure virtual package from `@robeasthope/infrastructure` to `@protomolecule/infrastructure` to avoid namespace confusion.

## Rationale

The `@robeasthope/*` namespace is reserved for packages that are published to npm (like `@robeasthope/ui`, `@robeasthope/eslint-config`, etc.).

The infrastructure package is a **virtual package** - it exists only for version tracking of CI/CD workflows, build configs, and tooling. It's never published to npm.

Using `@protomolecule/infrastructure` (matching the monorepo name) makes it clearer that this is an internal-only package for infrastructure tracking.

## Changes

Updated all references from `@robeasthope/infrastructure` to `@protomolecule/infrastructure`:

- ✅ `infrastructure/package.json` - Package name
- ✅ `infrastructure/README.md` - Documentation
- ✅ `infrastructure/CHANGELOG.md` - Changelog header
- ✅ `CLAUDE.md` - All changeset examples and instructions
- ✅ `.husky/pre-push` - Pre-push hook validation
- ✅ `.github/scripts/*.ts` - Release automation scripts
- ✅ `.github/scripts/*.test.ts` - Test files

## Impact

This is a **breaking change** for the infrastructure package only:

- ❌ Old changesets referencing `@robeasthope/infrastructure` will need updating
- ✅ No impact on actual published packages (`@robeasthope/ui`, etc.)
- ✅ Future infrastructure changesets will use `@protomolecule/infrastructure`

## Migration

After merge, when creating infrastructure changesets:

```bash
# Old (no longer works)
pnpm changeset
# Select: @robeasthope/infrastructure ❌

# New (correct)
pnpm changeset
# Select: @protomolecule/infrastructure ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)