### PR TITLE
feat(infrastructure): add automatic git config cleanup for act

### DIFF
--- a/.changeset/act-git-config-cleanup.md
+++ b/.changeset/act-git-config-cleanup.md
@@ -1,0 +1,35 @@
+---
+"@protomolecule/infrastructure": minor
+---
+
+Add automatic git config cleanup for act workflow testing
+
+**Problem:**
+The `act` tool (local GitHub Actions testing) sets local git config to simulate GitHub Actions:
+
+- `user.name=github-actions[bot]`
+- `user.email=github-actions[bot]@users.noreply.github.com`
+
+This config persists after act finishes, causing subsequent commits to be incorrectly attributed to github-actions[bot] instead of the actual developer.
+
+**Solution:**
+Added multiple cleanup approaches with comprehensive documentation:
+
+1. **Shell Wrapper (Recommended)** - Auto-cleanup function for `~/.zshrc` or `~/.bashrc`
+2. **Cleanup Script** - `.github/scripts/act-cleanup.sh` for manual cleanup
+3. **Manual Commands** - Direct git config commands for quick fixes
+
+**Changes:**
+
+- Added `.github/scripts/act-cleanup.sh` cleanup script with detailed comments
+- Added "Git Config Cleanup" section to CLAUDE.md with three solutions
+- Documented the problem, solutions, and verification steps
+
+**Benefits:**
+
+- ✅ Prevents commit attribution errors after act testing
+- ✅ Multiple solutions for different workflows
+- ✅ Clear documentation for team members
+- ✅ Automatic cleanup with shell wrapper
+
+Closes #253

--- a/.github/scripts/act-cleanup.sh
+++ b/.github/scripts/act-cleanup.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Script to clean up local git config set by 'act'
+#
+# Problem: The 'act' tool (local GitHub Actions testing) sets local git config:
+#   user.name=github-actions[bot]
+#   user.email=github-actions[bot]@users.noreply.github.com
+#
+# This config persists in .git/config after act finishes, overriding your
+# global git config. This means subsequent commits are incorrectly attributed
+# to github-actions[bot] instead of you.
+#
+# Solution: Run this script after using act to restore your git config.
+
+set -euo pipefail
+
+echo "🔍 Checking for local git config set by act..."
+
+if git config --local user.name >/dev/null 2>&1; then
+  echo "📝 Found local git config:"
+  echo "   user.name:  $(git config --local user.name)"
+  echo "   user.email: $(git config --local user.email 2>/dev/null || echo '(not set)')"
+
+  git config --local --unset user.name 2>/dev/null || true
+  git config --local --unset user.email 2>/dev/null || true
+
+  echo "✅ Cleaned up local git config"
+  echo ""
+  echo "Your global git config will now be used for commits:"
+  echo "   user.name:  $(git config --global user.name 2>/dev/null || echo '(not set)')"
+  echo "   user.email: $(git config --global user.email 2>/dev/null || echo '(not set)')"
+else
+  echo "✅ No local git config found - nothing to clean up"
+fi


### PR DESCRIPTION
## Summary

Adds automatic git config cleanup solutions for developers using `act` (local GitHub Actions testing). Prevents commit attribution errors caused by act's persistent local git config.

Closes #253

## Problem

When testing GitHub Actions workflows locally with `act`, the tool sets local git config to simulate the GitHub Actions environment:

```ini
user.name=github-actions[bot]
user.email=github-actions[bot]@users.noreply.github.com
```

**Issue:** This config persists in `.git/config` after act finishes, overriding the developer's global git config. This means:
- ❌ Subsequent commits are attributed to `github-actions[bot]`
- ❌ Claude Code commits show wrong author
- ❌ Manual commits show wrong author
- ❌ Developers must remember to manually clean up

## Solution

Added three cleanup approaches with comprehensive documentation:

### 1. Shell Wrapper (Recommended) ✨

Auto-cleanup function for `~/.zshrc` or `~/.bashrc`:

```bash
act() {
  command act "$@"
  local exit_code=$?
  
  if git config --local user.name > /dev/null 2>&1; then
    git config --local --unset user.name 2>/dev/null || true
    git config --local --unset user.email 2>/dev/null || true
    echo "🧹 Cleaned up local git config"
  fi
  
  return $exit_code
}
```

**Benefits:**
- ✅ Automatic - no manual cleanup needed
- ✅ Transparent - preserves act's exit code
- ✅ Safe - only runs if local config exists

### 2. Cleanup Script

Added `.github/scripts/act-cleanup.sh` for manual cleanup:

```bash
.github/scripts/act-cleanup.sh
```

**Features:**
- Detects local git config set by act
- Shows before/after config values
- Verifies global config will be used
- Executable and well-documented

### 3. Manual Commands

Quick manual cleanup:

```bash
git config --local --unset user.name
git config --local --unset user.email
```

## Changes

### New Files

- `.github/scripts/act-cleanup.sh` - Executable cleanup script with detailed comments and user-friendly output

### Documentation

- Added "Git Config Cleanup" section to CLAUDE.md with:
  - Problem explanation
  - Three cleanup solutions
  - How each solution works
  - Verification commands

## Benefits

✅ **Prevents attribution errors** - No more commits by github-actions[bot]  
✅ **Multiple solutions** - Choose automatic or manual based on workflow  
✅ **Well documented** - Clear instructions for all team members  
✅ **Easy to use** - Simple script and shell function  
✅ **Developer experience** - Removes friction from workflow testing

## Testing

The script can be tested by:

1. Running `act` to test a workflow
2. Checking local config: `git config --local user.name`
3. Running `.github/scripts/act-cleanup.sh`
4. Verifying config is cleaned: `git config --local user.name` (should be empty)

## Reference

See complete implementation in Hecate:
- Issue: https://github.com/RobEasthope/hecate/issues/221
- PR: https://github.com/RobEasthope/hecate/pull/231

🤖 Generated with [Claude Code](https://claude.com/claude-code)