### PR TITLE
fix(eslint-config): add plugin aliasing for import/import-x compatibility

### DIFF
--- a/.changeset/fix-plugin-import-aliasing.md
+++ b/.changeset/fix-plugin-import-aliasing.md
@@ -1,0 +1,44 @@
+---
+"@robeasthope/eslint-config": patch
+---
+
+Add plugin aliasing to map eslint-plugin-import-x as "import"
+
+**Problem:**
+`eslint-config-canonical` references rules using plugin name `"import"`, but the actual installed package is `eslint-plugin-import-x`. This caused ESLint flat config to fail with:
+
+```text
+A configuration object specifies rule "import/no-unresolved", but could not find plugin "import".
+```
+
+**Solution:**
+Added plugin aliasing to register `eslint-plugin-import-x` as both `"import"` and `"import-x"`:
+
+- `"import"` - Alias for backward compatibility with canonical config
+- `"import-x"` - Standard modern name
+
+**Changes:**
+
+- Imported `pluginImportX` explicitly in index.ts
+- Added plugin registration config object before canonical config
+- Registered plugin under both names for compatibility
+
+**Benefits:**
+
+- ✅ Backward compatibility with canonical config's "import" references
+- ✅ No consumer changes needed - workarounds can be removed
+- ✅ Future-proof - works when canonical eventually updates
+- ✅ Clean migration path - can remove "import" alias later
+
+**Impact:**
+Consumers can now remove workarounds like:
+```typescript
+export const astroImportFix = {
+  files: ["**/*.astro"],
+  rules: {
+    "import/no-unresolved": "off",
+  },
+};
+```
+
+Closes #259

--- a/packages/eslint-config/index.ts
+++ b/packages/eslint-config/index.ts
@@ -7,6 +7,7 @@ import { preferences } from "./rules/preferences";
 import { storybook } from "./rules/storybook";
 import { typescriptOverrides } from "./rules/typescriptOverrides";
 import eslintConfigCanonicalAuto from "eslint-config-canonical/auto";
+import pluginImportX from "eslint-plugin-import-x";
 
 // Re-export plugins for workspace consumers
 // This fixes plugin resolution when eslint-config is installed at monorepo root
@@ -27,6 +28,16 @@ export { default as pluginUnicorn } from "eslint-plugin-unicorn";
 export * as typescriptEslint from "typescript-eslint";
 
 const config: any[] = [
+  // Plugin aliasing for eslint-config-canonical compatibility
+  // Canonical config references "import" but package is "eslint-plugin-import-x"
+  // Register under both names for backward compatibility
+  // See: https://github.com/RobEasthope/protomolecule/issues/259
+  {
+    plugins: {
+      import: pluginImportX, // Alias for canonical config compatibility
+      "import-x": pluginImportX, // Standard name
+    },
+  },
   ignoredFileAndFolders,
   ...eslintConfigCanonicalAuto,
   packageJson,


### PR DESCRIPTION
## Summary

Fixes plugin name mismatch between `eslint-config-canonical` (uses `"import"`) and the actual package (`eslint-plugin-import-x`) by registering the plugin under both names.

Closes #259

## Problem

`eslint-config-canonical` references rules using plugin name `"import"`:
```typescript
rules: {
  "import/no-unresolved": "error"
}
```

But the actual package is `eslint-plugin-import-x`, causing ESLint flat config to fail:
```text
A configuration object specifies rule "import/no-unresolved", but could not find plugin "import".
```

This forced consumers to add workarounds disabling import rules.

## Solution

Added plugin aliasing to register `eslint-plugin-import-x` under both names:

```typescript
{
  plugins: {
    import: pluginImportX,      // Alias for canonical config compatibility
    "import-x": pluginImportX,  // Standard name
  }
}
```

The plugin registration happens **before** the canonical config is spread, ensuring the "import" alias is available when canonical's rules reference it.

## Changes

- Imported `pluginImportX` explicitly in `index.ts:10`
- Added plugin registration config object at `index.ts:31-40`
- Registered plugin under both `"import"` and `"import-x"` names
- Added comprehensive comments explaining the aliasing

## Benefits

- ✅ **Backward compatibility** - Works with canonical config's "import" references
- ✅ **No consumer changes needed** - Consumers can remove workarounds
- ✅ **Future-proof** - Works when canonical eventually migrates to import-x
- ✅ **Clean migration path** - Can remove "import" alias in future versions

## Impact on Consumers

**Before (with workaround):**
```typescript
export const astroImportFix = {
  files: ["**/*.astro"],
  rules: {
    "import/no-unresolved": "off",  // Had to disable due to plugin error
  },
};
```

**After (workaround can be removed):**
```typescript
// No workaround needed! Import rules work correctly
```

## Testing

Tested by:
1. ✅ Building the package successfully
2. ✅ Running lint on eslint-config package itself
3. Ready for testing in hecate repo (apps/markdown)

## Breaking Changes

None - this is a patch release. Only adds plugin aliasing without changing any existing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)