### PR TITLE
fix(eslint-config): make astro-eslint-parser a peerDependency for proper resolution

### DIFF
--- a/.changeset/fix-astro-parser-resolution.md
+++ b/.changeset/fix-astro-parser-resolution.md
@@ -1,0 +1,46 @@
+---
+"@robeasthope/eslint-config": patch
+---
+
+Fix Astro parser resolution by making astro-eslint-parser a peerDependency
+
+**Problem:**
+Even though the Astro parser was configured correctly in the ESLint config, ESLint was still using the JavaScript parser (acorn/espree) for `.astro` files in consumer workspaces. This caused parsing errors like:
+
+```text
+error  Parsing error: The keyword 'interface' is reserved
+```
+
+**Root Cause:**
+The `astro-eslint-parser` was a regular dependency of `@robeasthope/eslint-config`, installed in its `node_modules`. When ESLint ran from a consumer workspace subdirectory, it couldn't resolve the parser module even though the config referenced it correctly.
+
+**Solution:**
+Moved `astro-eslint-parser` from dependencies to **optional peerDependencies**:
+
+- Consumers install the parser at workspace root where ESLint can resolve it
+- Parser module is accessible from consumer's execution context
+- Re-exported parser for explicit imports if needed
+
+**Changes:**
+
+- Moved `astro-eslint-parser` to peerDependencies (optional)
+- Added to devDependencies for package's own linting
+- Re-exported parser: `export { default as astroParser } from "astro-eslint-parser"`
+
+**Installation (updated):**
+```bash
+# For projects using Astro
+pnpm add -D -w \
+  astro-eslint-parser \
+  eslint-plugin-astro \
+  [... other plugins]
+```
+
+**Benefits:**
+
+- ✅ Astro parser now resolves correctly in monorepo workspaces
+- ✅ `.astro` files parse without errors
+- ✅ No more fallback to JavaScript parser
+- ✅ Astro-specific syntax (interfaces, components) works correctly
+
+Related to #261

--- a/packages/eslint-config/index.ts
+++ b/packages/eslint-config/index.ts
@@ -9,6 +9,8 @@ import { typescriptOverrides } from "./rules/typescriptOverrides";
 import eslintConfigCanonicalAuto from "eslint-config-canonical/auto";
 import pluginImportX from "eslint-plugin-import-x";
 
+// Re-export Astro parser for proper resolution in monorepo workspaces
+export { default as astroParser } from "astro-eslint-parser";
 // Re-export plugins for workspace consumers
 // This fixes plugin resolution when eslint-config is installed at monorepo root
 // but ESLint is run from workspace subdirectories

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -52,7 +52,6 @@
     "tsc": "tsc --noEmit"
   },
   "dependencies": {
-    "astro-eslint-parser": "^1.0.0",
     "eslint-config-canonical": "^45.0.1"
   },
   "devDependencies": {
@@ -60,6 +59,7 @@
     "@robeasthope/tsconfig": "workspace:*",
     "@types/eslint": "^9.6.1",
     "@types/node": "^24.6.2",
+    "astro-eslint-parser": "^1.0.0",
     "eslint-plugin-astro": "^1.0.0",
     "eslint-plugin-import-x": "^4.16.1",
     "eslint-plugin-jsdoc": "^60.8.2",
@@ -77,6 +77,7 @@
     "typescript-eslint": "^8.46.0"
   },
   "peerDependencies": {
+    "astro-eslint-parser": "^1.0.0",
     "eslint": "^8.57.0 || ^9.0.0",
     "eslint-plugin-astro": "^1.0.0",
     "eslint-plugin-import-x": "^4.16.1",
@@ -92,6 +93,9 @@
     "typescript-eslint": "^8.46.0"
   },
   "peerDependenciesMeta": {
+    "astro-eslint-parser": {
+      "optional": true
+    },
     "eslint-plugin-astro": {
       "optional": true
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,9 +91,6 @@ importers:
 
   packages/eslint-config:
     dependencies:
-      astro-eslint-parser:
-        specifier: ^1.0.0
-        version: 1.2.2
       eslint:
         specifier: ^8.57.0 || ^9.0.0
         version: 9.37.0(jiti@2.6.1)
@@ -113,6 +110,9 @@ importers:
       "@types/node":
         specifier: ^24.6.2
         version: 24.6.2
+      astro-eslint-parser:
+        specifier: ^1.0.0
+        version: 1.2.2
       eslint-plugin-astro:
         specifier: ^1.0.0
         version: 1.3.1(eslint@9.37.0(jiti@2.6.1))


### PR DESCRIPTION
## Summary

Fixes Astro parser resolution issues by moving `astro-eslint-parser` from dependencies to peerDependencies, ensuring the parser is accessible when ESLint runs from consumer workspace subdirectories.

Closes #261

## Problem

Even with v4.0.1's peerDependencies and plugin aliasing fixes, Astro files were still failing to parse:

```
error  Parsing error: The keyword 'interface' is reserved
```

**Debug showed:**
- `--print-config` displayed the parser correctly: `"parser": "astro-eslint-parser@1.2.2"`
- But ESLint was using JavaScript parser (acorn/espree) instead
- Debug output: `eslint:languages:js Parsing: /path/to/file.astro`

## Root Cause

The `astro-eslint-parser` was a regular **dependency** of `@robeasthope/eslint-config`:
```
@robeasthope/eslint-config/
└── node_modules/
    └── astro-eslint-parser/  ← Installed here
```

When ESLint ran from a consumer workspace subdirectory (`apps/markdown/`), Node.js couldn't resolve the parser module even though the ESLint config referenced it. The parser was "trapped" in `eslint-config`'s nested `node_modules`.

## Solution

Moved `astro-eslint-parser` to **optional peerDependencies**:

```json
{
  "peerDependencies": {
    "astro-eslint-parser": "^1.0.0",
    // ... other deps
  },
  "peerDependenciesMeta": {
    "astro-eslint-parser": {
      "optional": true
    }
  }
}
```

Now consumers install the parser at workspace root where ESLint can resolve it from any subdirectory.

## Changes

1. **Moved parser to peerDependencies** (optional)
   - From: `dependencies.astro-eslint-parser`
   - To: `peerDependencies.astro-eslint-parser` + `peerDependenciesMeta.astro-eslint-parser.optional: true`

2. **Added to devDependencies** for package's own linting

3. **Re-exported parser** for explicit imports:
   ```typescript
   export { default as astroParser } from "astro-eslint-parser";
   ```

## Installation (Updated)

Projects using Astro must now install the parser as a peer dependency:

```bash
pnpm add -D -w \
  astro-eslint-parser \
  eslint-plugin-astro \
  eslint-plugin-import-x \
  # ... other plugins
```

**Note:** The `-w` flag installs at workspace root, making the parser resolvable from all subdirectories.

## Benefits

- ✅ **Astro parser resolves correctly** in monorepo workspaces
- ✅ **`.astro` files parse without errors** - no more "interface is reserved" errors
- ✅ **No fallback to JS parser** - Astro-specific syntax works
- ✅ **Consistent with other peer deps** - all plugins and parsers installed at root

## Testing

After upgrading to v4.0.2:

1. **Install parser at root:**
   ```bash
   pnpm add -D -w astro-eslint-parser
   ```

2. **Remove Astro ignore workaround:**
   ```diff
   - export const ignoreAstroFiles = {
   -   ignores: ["**/*.astro"],
   - };
   
   - export default [...baseConfig, ignoreAstroFiles, customRules];
   + export default [...baseConfig, customRules];
   ```

3. **Test linting:**
   ```bash
   pnpm --filter=@your-app/name lint
   ```

Astro files should now parse and lint correctly!

## Technical Details

This is the same pattern used for plugins in v4.0.0:
- **Problem**: Plugins/parsers in nested `node_modules` aren't resolvable
- **Solution**: Make them peerDependencies so consumers install at workspace root
- **Result**: Module resolution works from any execution context

The parser object in the config comes from the consumer's installation, not the config package's installation.

---

Related: #261, #259, #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)