### PR TITLE
feat: replace AI summaries with CHANGELOG-based extraction

### DIFF
--- a/.changeset/feat-changelog-based-releases.md
+++ b/.changeset/feat-changelog-based-releases.md
@@ -1,0 +1,68 @@
+---
+"@protomolecule/infrastructure": minor
+---
+
+Replace AI-generated release summaries with CHANGELOG-based extraction
+
+**Problem:**
+The current release workflow uses GitHub Models API to generate AI summaries, which causes multiple issues:
+
+- ❌ **Rate limits:** 150 requests/day limit
+- ❌ **Complex permissions:** Requires `id-token: write` permission
+- ❌ **Token usage:** Unnecessary AI token consumption
+- ❌ **Re-writing existing content:** CHANGELOGs already contain all the information
+- ❌ **Missing links:** AI summaries don't preserve PR/commit links from changesets
+
+**Solution:**
+Rewrote `generate-summary.ts` to extract release notes directly from package CHANGELOG.md files that changesets automatically generates.
+
+**Implementation:**
+
+1. **New Functions:**
+   - `findChangelogPath()` - Locates package CHANGELOGs in packages/, apps/, infrastructure/
+   - `extractChangelogSection()` - Extracts version-specific content using regex
+   - `generateChangelogBasedSummary()` - Combines all package sections
+   - Maintains same input/output interface for workflow compatibility
+
+2. **Workflow Updates:**
+   - Removed `GITHUB_TOKEN` env var from generate-summary step
+   - Removed `USED_AI` file check
+   - Updated comments to reflect CHANGELOG-based approach
+
+3. **Comprehensive Tests:**
+   - 22 tests covering all functions (84 total tests across all scripts)
+   - Tests for CHANGELOG path discovery
+   - Tests for version section extraction
+   - Tests for multi-line content and markdown link preservation
+   - Tests for fallback behavior
+
+**Benefits:**
+
+- ✅ **Zero rate limits** - No API calls
+- ✅ **Zero tokens** - No AI usage
+- ✅ **Faster execution** - Direct file reads vs API calls
+- ✅ **More accurate** - Uses exact changeset content with PR/commit links preserved
+- ✅ **Simpler maintenance** - No API key management or permission configuration
+- ✅ **Better formatting** - Preserves markdown links: [`abc123`](url) and [#42](url)
+
+**Example Output:**
+```markdown
+## Workspace Updates
+
+* @robeasthope/eslint-config@4.1.0
+* @protomolecule/infrastructure@2.1.0
+
+## 4.1.0
+
+### Minor Changes
+
+- [`7d563c1`](https://github.com/RobEasthope/protomolecule/commit/...) [#266](https://github.com/RobEasthope/protomolecule/pull/266) - Add common import ignore patterns...
+
+## 2.1.0
+
+### Minor Changes
+
+- [`abc1234`](https://github.com/RobEasthope/protomolecule/commit/...) - Update build configuration...
+```
+
+Closes #269

--- a/.github/scripts/generate-summary.test.ts
+++ b/.github/scripts/generate-summary.test.ts
@@ -1,231 +1,486 @@
 import { describe, it, expect } from "vitest";
 import {
-  determineSummaryDepth,
-  formatPackageSummary,
-  generateFallbackSummary,
-  validateAIResponse,
+  findChangelogPath,
+  extractChangelogSection,
+  generateChangelogBasedSummary,
   type Package,
-  type BumpType,
 } from "./generate-summary";
 
-describe("determineSummaryDepth", () => {
-  it("returns brief for single package patch", () => {
-    const result = determineSummaryDepth("patch", 1);
+describe("findChangelogPath", () => {
+  it("finds CHANGELOG in packages directory", () => {
+    const mockFileExists = (path: string) =>
+      path.includes("packages/eslint-config/CHANGELOG.md");
 
-    expect(result).toBe("brief");
+    const result = findChangelogPath(
+      "@robeasthope/eslint-config",
+      "/repo",
+      mockFileExists,
+    );
+
+    expect(result).toBe("/repo/packages/eslint-config/CHANGELOG.md");
   });
 
-  it("returns brief for single package minor", () => {
-    const result = determineSummaryDepth("minor", 1);
+  it("finds CHANGELOG in apps directory", () => {
+    const mockFileExists = (path: string) =>
+      path.includes("apps/my-app/CHANGELOG.md");
 
-    expect(result).toBe("brief");
+    const result = findChangelogPath(
+      "@robeasthope/my-app",
+      "/repo",
+      mockFileExists,
+    );
+
+    expect(result).toBe("/repo/apps/my-app/CHANGELOG.md");
   });
 
-  it("returns detailed for single package major", () => {
-    const result = determineSummaryDepth("major", 1);
+  it("finds CHANGELOG in infrastructure directory", () => {
+    const mockFileExists = (path: string) =>
+      path.includes("infrastructure/CHANGELOG.md");
 
-    expect(result).toBe("detailed");
+    const result = findChangelogPath(
+      "@protomolecule/infrastructure",
+      "/repo",
+      mockFileExists,
+    );
+
+    expect(result).toBe("/repo/infrastructure/CHANGELOG.md");
   });
 
-  it("returns comprehensive for major with 2 packages", () => {
-    const result = determineSummaryDepth("major", 2);
+  it("returns null when CHANGELOG not found", () => {
+    const mockFileExists = () => false;
 
-    expect(result).toBe("comprehensive");
+    const result = findChangelogPath(
+      "@robeasthope/nonexistent",
+      "/repo",
+      mockFileExists,
+    );
+
+    expect(result).toBeNull();
   });
 
-  it("returns comprehensive for major with 3+ packages", () => {
-    const result = determineSummaryDepth("major", 5);
+  it("handles package names without scope", () => {
+    const mockFileExists = (path: string) =>
+      path.includes("packages/eslint-config/CHANGELOG.md");
 
-    expect(result).toBe("comprehensive");
+    const result = findChangelogPath("eslint-config", "/repo", mockFileExists);
+
+    expect(result).toBe("/repo/packages/eslint-config/CHANGELOG.md");
   });
 
-  it("returns detailed for 3+ packages with minor bump", () => {
-    const result = determineSummaryDepth("minor", 3);
+  it("checks packages directory before apps directory", () => {
+    const checkedPaths: string[] = [];
+    const mockFileExists = (path: string) => {
+      checkedPaths.push(path);
+      return path.includes("apps/ui/CHANGELOG.md");
+    };
 
-    expect(result).toBe("detailed");
-  });
+    const result = findChangelogPath(
+      "@robeasthope/ui",
+      "/repo",
+      mockFileExists,
+    );
 
-  it("returns detailed for 3+ packages with patch bump", () => {
-    const result = determineSummaryDepth("patch", 3);
-
-    expect(result).toBe("detailed");
-  });
-
-  it("returns brief for 2 packages with minor bump", () => {
-    const result = determineSummaryDepth("minor", 2);
-
-    expect(result).toBe("brief");
+    expect(result).toBe("/repo/apps/ui/CHANGELOG.md");
+    expect(checkedPaths[0]).toContain("packages/ui");
+    expect(checkedPaths[1]).toContain("apps/ui");
   });
 });
 
-describe("formatPackageSummary", () => {
-  it("formats single package", () => {
-    const packages: Package[] = [
-      { name: "@robeasthope/markdown", version: "1.0.0" },
-    ];
+describe("extractChangelogSection", () => {
+  it("extracts simple version section", () => {
+    const changelog = `# Package Name
 
-    const result = formatPackageSummary(packages);
+## 1.0.0
 
-    expect(result).toBe("@robeasthope/markdown@1.0.0");
+### Patch Changes
+
+- Fix something
+
+## 0.9.0
+
+### Minor Changes
+
+- Add feature
+`;
+
+    const result = extractChangelogSection(changelog, "1.0.0");
+
+    expect(result).toContain("## 1.0.0");
+    expect(result).toContain("Fix something");
+    expect(result).not.toContain("## 0.9.0");
+    expect(result).not.toContain("Add feature");
   });
 
-  it("formats multiple packages with newlines", () => {
+  it("extracts version section with multi-line content", () => {
+    const changelog = `# @robeasthope/eslint-config
+
+## 4.1.0
+
+### Minor Changes
+
+- [\`7d563c1\`](https://github.com/RobEasthope/protomolecule/commit/7d563c1) [#266](https://github.com/RobEasthope/protomolecule/pull/266) - Add common import ignore patterns to Astro rules
+
+  **Enhancement:**
+  Added commonly-needed import ignore patterns to the Astro configuration.
+
+  **Benefits:**
+  - ✅ Reduces boilerplate in consumer configs
+  - ✅ Covers 90%+ of Astro projects out of the box
+
+## 4.0.2
+
+### Patch Changes
+
+- Fix parser resolution
+`;
+
+    const result = extractChangelogSection(changelog, "4.1.0");
+
+    expect(result).toContain("## 4.1.0");
+    expect(result).toContain("Add common import ignore patterns");
+    expect(result).toContain("**Enhancement:**");
+    expect(result).toContain("✅ Reduces boilerplate");
+    expect(result).not.toContain("## 4.0.2");
+    expect(result).not.toContain("Fix parser resolution");
+  });
+
+  it("extracts last version section (no next version)", () => {
+    const changelog = `# Package
+
+## 2.0.0
+
+### Major Changes
+
+- Breaking change
+
+## 1.0.0
+
+### Minor Changes
+
+- Initial release
+`;
+
+    const result = extractChangelogSection(changelog, "1.0.0");
+
+    expect(result).toContain("## 1.0.0");
+    expect(result).toContain("Initial release");
+    expect(result).not.toContain("Breaking change");
+  });
+
+  it("returns null when version not found", () => {
+    const changelog = `# Package
+
+## 1.0.0
+
+### Patch Changes
+
+- Fix something
+`;
+
+    const result = extractChangelogSection(changelog, "2.0.0");
+
+    expect(result).toBeNull();
+  });
+
+  it("handles version at start of file", () => {
+    const changelog = `## 1.0.0
+
+### Patch Changes
+
+- Fix something
+
+## 0.9.0
+
+### Minor Changes
+
+- Add feature
+`;
+
+    const result = extractChangelogSection(changelog, "1.0.0");
+
+    expect(result).toContain("## 1.0.0");
+    expect(result).toContain("Fix something");
+    expect(result).not.toContain("## 0.9.0");
+  });
+
+  it("preserves markdown links in extracted section", () => {
+    const changelog = `# Package
+
+## 1.0.0
+
+### Patch Changes
+
+- [\`abc123\`](https://github.com/user/repo/commit/abc123) [#42](https://github.com/user/repo/pull/42) - Fix something
+
+## 0.9.0
+`;
+
+    const result = extractChangelogSection(changelog, "1.0.0");
+
+    expect(result).toContain("[`abc123`]");
+    expect(result).toContain("(https://github.com/user/repo/commit/abc123)");
+    expect(result).toContain("[#42]");
+    expect(result).toContain("(https://github.com/user/repo/pull/42)");
+  });
+
+  it("handles version sections with code blocks", () => {
+    const changelog = `# Package
+
+## 1.0.0
+
+### Minor Changes
+
+- New feature
+
+  \`\`\`typescript
+  const example = "code";
+  \`\`\`
+
+## 0.9.0
+`;
+
+    const result = extractChangelogSection(changelog, "1.0.0");
+
+    expect(result).toContain("## 1.0.0");
+    expect(result).toContain("```typescript");
+    expect(result).toContain('const example = "code";');
+    expect(result).not.toContain("## 0.9.0");
+  });
+
+  it("handles version with special characters", () => {
+    const changelog = `# Package
+
+## 1.0.0-beta.1
+
+### Patch Changes
+
+- Beta release
+
+## 0.9.0
+`;
+
+    const result = extractChangelogSection(changelog, "1.0.0-beta.1");
+
+    expect(result).toContain("## 1.0.0-beta.1");
+    expect(result).toContain("Beta release");
+  });
+});
+
+describe("generateChangelogBasedSummary", () => {
+  it("generates summary for single package", () => {
     const packages: Package[] = [
-      { name: "@robeasthope/markdown", version: "1.0.0" },
-      { name: "@robeasthope/ui", version: "2.1.0" },
-      { name: "@protomolecule/infrastructure", version: "0.3.0" },
+      { name: "@robeasthope/eslint-config", version: "4.1.0" },
     ];
 
-    const result = formatPackageSummary(packages);
+    const mockFileExists = (path: string) =>
+      path.includes("eslint-config/CHANGELOG.md");
 
-    expect(result).toBe(
-      "@robeasthope/markdown@1.0.0\n@robeasthope/ui@2.1.0\n@protomolecule/infrastructure@0.3.0",
+    const mockReadFile = () => `# @robeasthope/eslint-config
+
+## 4.1.0
+
+### Minor Changes
+
+- Add new feature
+`;
+
+    const result = generateChangelogBasedSummary(
+      packages,
+      "/repo",
+      mockFileExists,
+      mockReadFile,
+    );
+
+    expect(result).toContain("## Workspace Updates");
+    expect(result).toContain("* @robeasthope/eslint-config@4.1.0");
+    expect(result).toContain("## 4.1.0");
+    expect(result).toContain("Add new feature");
+  });
+
+  it("generates summary for multiple packages", () => {
+    const packages: Package[] = [
+      { name: "@robeasthope/eslint-config", version: "4.1.0" },
+      { name: "@protomolecule/infrastructure", version: "2.1.0" },
+    ];
+
+    const mockFileExists = (path: string) =>
+      path.includes("eslint-config/CHANGELOG.md") ||
+      path.includes("infrastructure/CHANGELOG.md");
+
+    const mockReadFile = (path: string) => {
+      if (path.includes("eslint-config")) {
+        return `## 4.1.0\n\n### Minor Changes\n\n- ESLint feature`;
+      }
+      if (path.includes("infrastructure")) {
+        return `## 2.1.0\n\n### Minor Changes\n\n- Infrastructure update`;
+      }
+      return "";
+    };
+
+    const result = generateChangelogBasedSummary(
+      packages,
+      "/repo",
+      mockFileExists,
+      mockReadFile,
+    );
+
+    expect(result).toContain("* @robeasthope/eslint-config@4.1.0");
+    expect(result).toContain("* @protomolecule/infrastructure@2.1.0");
+    expect(result).toContain("ESLint feature");
+    expect(result).toContain("Infrastructure update");
+  });
+
+  it("handles missing CHANGELOG files gracefully", () => {
+    const packages: Package[] = [
+      { name: "@robeasthope/nonexistent", version: "1.0.0" },
+    ];
+
+    const mockFileExists = () => false;
+    const mockReadFile = () => "";
+
+    const result = generateChangelogBasedSummary(
+      packages,
+      "/repo",
+      mockFileExists,
+      mockReadFile,
+    );
+
+    expect(result).toContain("## Workspace Updates");
+    expect(result).toContain("* @robeasthope/nonexistent@1.0.0");
+    expect(result).toContain(
+      "_See individual package changelogs for detailed changes._",
     );
   });
 
-  it("handles empty array", () => {
-    const result = formatPackageSummary([]);
-
-    expect(result).toBe("");
-  });
-
-  it("handles pre-release versions", () => {
+  it("handles version not found in CHANGELOG", () => {
     const packages: Package[] = [
-      { name: "@robeasthope/markdown", version: "1.0.0-beta.1" },
+      { name: "@robeasthope/eslint-config", version: "5.0.0" },
     ];
 
-    const result = formatPackageSummary(packages);
+    const mockFileExists = (path: string) =>
+      path.includes("eslint-config/CHANGELOG.md");
 
-    expect(result).toBe("@robeasthope/markdown@1.0.0-beta.1");
-  });
-});
+    const mockReadFile = () => `## 4.1.0\n\n### Minor Changes\n\n- Old version`;
 
-describe("generateFallbackSummary", () => {
-  it("generates template for single package", () => {
-    const packages: Package[] = [
-      { name: "@robeasthope/markdown", version: "1.0.0" },
-    ];
-
-    const result = generateFallbackSummary(packages);
+    const result = generateChangelogBasedSummary(
+      packages,
+      "/repo",
+      mockFileExists,
+      mockReadFile,
+    );
 
     expect(result).toContain("## Workspace Updates");
-    expect(result).toContain("* @robeasthope/markdown@1.0.0");
-    expect(result).toContain("AI summary unavailable");
-    expect(result).toContain("see individual package changelogs");
+    expect(result).toContain("* @robeasthope/eslint-config@5.0.0");
+    // Should include fallback message when version not found
+    expect(result).toContain(
+      "_See individual package changelogs for detailed changes._",
+    );
   });
 
-  it("generates template for multiple packages", () => {
+  it("preserves markdown formatting from CHANGELOGs", () => {
     const packages: Package[] = [
-      { name: "@robeasthope/markdown", version: "1.0.0" },
-      { name: "@robeasthope/ui", version: "2.1.0" },
+      { name: "@robeasthope/eslint-config", version: "4.1.0" },
     ];
 
-    const result = generateFallbackSummary(packages);
+    const mockFileExists = (path: string) =>
+      path.includes("eslint-config/CHANGELOG.md");
 
-    expect(result).toContain("* @robeasthope/markdown@1.0.0");
-    expect(result).toContain("* @robeasthope/ui@2.1.0");
+    const mockReadFile = () => `## 4.1.0
+
+### Minor Changes
+
+- [\`abc123\`](https://github.com/user/repo/commit/abc123) [#42](https://github.com/user/repo/pull/42) - New feature
+
+  **Benefits:**
+  - ✅ Benefit 1
+  - ✅ Benefit 2
+`;
+
+    const result = generateChangelogBasedSummary(
+      packages,
+      "/repo",
+      mockFileExists,
+      mockReadFile,
+    );
+
+    expect(result).toContain("[`abc123`]");
+    expect(result).toContain("[#42]");
+    expect(result).toContain("**Benefits:**");
+    expect(result).toContain("✅ Benefit 1");
   });
 
   it("handles empty packages array", () => {
-    const result = generateFallbackSummary([]);
+    const packages: Package[] = [];
+
+    const result = generateChangelogBasedSummary(
+      packages,
+      "/repo",
+      () => false,
+      () => "",
+    );
 
     expect(result).toContain("## Workspace Updates");
-    expect(result).toContain("AI summary unavailable");
   });
 
-  it("formats with markdown list items", () => {
+  it("handles read errors gracefully", () => {
     const packages: Package[] = [
-      { name: "@robeasthope/test", version: "1.0.0" },
+      { name: "@robeasthope/eslint-config", version: "4.1.0" },
     ];
 
-    const result = generateFallbackSummary(packages);
+    const mockFileExists = (path: string) =>
+      path.includes("eslint-config/CHANGELOG.md");
 
-    // Should start with * for markdown list
-    expect(result).toMatch(/\* @robeasthope\/test@1\.0\.0/);
-  });
-});
+    const mockReadFile = () => {
+      throw new Error("EACCES: permission denied");
+    };
 
-describe("validateAIResponse", () => {
-  it("validates valid string response", () => {
-    const content = "This is a valid AI response with sufficient length.";
-
-    const result = validateAIResponse(content);
-
-    expect(result).toBe(content);
-  });
-
-  it("throws on empty string", () => {
-    expect(() => validateAIResponse("")).toThrow(
-      "AI response is empty or not a string",
+    const result = generateChangelogBasedSummary(
+      packages,
+      "/repo",
+      mockFileExists,
+      mockReadFile,
     );
+
+    expect(result).toContain("## Workspace Updates");
+    expect(result).toContain("* @robeasthope/eslint-config@4.1.0");
   });
 
-  it("throws on null", () => {
-    expect(() => validateAIResponse(null)).toThrow(
-      "AI response is empty or not a string",
+  it("separates package sections with blank lines", () => {
+    const packages: Package[] = [
+      { name: "@robeasthope/eslint-config", version: "4.1.0" },
+      { name: "@protomolecule/infrastructure", version: "2.1.0" },
+    ];
+
+    const mockFileExists = (path: string) => {
+      return (
+        path.includes("eslint-config/CHANGELOG.md") ||
+        path.includes("infrastructure/CHANGELOG.md")
+      );
+    };
+
+    const mockReadFile = (path: string) => {
+      if (path.includes("eslint-config")) {
+        return `## 4.1.0\n\n### Minor Changes\n\n- ESLint feature`;
+      }
+      if (path.includes("infrastructure")) {
+        return `## 2.1.0\n\n### Minor Changes\n\n- Infrastructure update`;
+      }
+      return "";
+    };
+
+    const result = generateChangelogBasedSummary(
+      packages,
+      "/repo",
+      mockFileExists,
+      mockReadFile,
     );
-  });
 
-  it("throws on undefined", () => {
-    expect(() => validateAIResponse(undefined)).toThrow(
-      "AI response is empty or not a string",
-    );
-  });
-
-  it("throws on number", () => {
-    expect(() => validateAIResponse(123)).toThrow(
-      "AI response is empty or not a string",
-    );
-  });
-
-  it("throws on object", () => {
-    expect(() => validateAIResponse({ content: "test" })).toThrow(
-      "AI response is empty or not a string",
-    );
-  });
-
-  it("throws on too short response", () => {
-    expect(() => validateAIResponse("short")).toThrow(
-      "AI response too short: 5 characters",
-    );
-  });
-
-  it("throws on response at 9 characters (boundary)", () => {
-    expect(() => validateAIResponse("123456789")).toThrow(
-      "AI response too short: 9 characters",
-    );
-  });
-
-  it("accepts response at 10 characters (boundary)", () => {
-    const content = "1234567890";
-
-    const result = validateAIResponse(content);
-
-    expect(result).toBe(content);
-  });
-
-  it("throws on too long response", () => {
-    const content = "x".repeat(5001);
-
-    expect(() => validateAIResponse(content)).toThrow(
-      "AI response too long: 5001 characters",
-    );
-  });
-
-  it("accepts response at 5000 characters (boundary)", () => {
-    const content = "x".repeat(5000);
-
-    const result = validateAIResponse(content);
-
-    expect(result).toBe(content);
-  });
-
-  it("accepts typical AI response length", () => {
-    const content =
-      "## Summary\n\nThis release includes updates to the markdown package with improved performance and new features.\n\n## Highlights\n* ✨ New feature\n* ⚡ Performance improvements";
-
-    const result = validateAIResponse(content);
-
-    expect(result).toBe(content);
+    // Should have double newlines between the two package sections
+    expect(result).toContain("## 4.1.0");
+    expect(result).toContain("## 2.1.0");
+    expect(result).toContain("ESLint feature");
+    expect(result).toContain("Infrastructure update");
+    // Check that sections are separated by double newlines
+    expect(result).toMatch(/ESLint feature\n\n## 2\.1\.0/);
   });
 });

--- a/.github/scripts/generate-summary.ts
+++ b/.github/scripts/generate-summary.ts
@@ -2,9 +2,8 @@
 /**
  * generate-summary.ts
  *
- * Generates AI-powered release summaries using GitHub Models API.
- * Reads published package information and creates contextual release notes
- * with varying levels of detail based on release significance.
+ * Generates release summaries by extracting version-specific sections from package
+ * CHANGELOG.md files that changesets automatically generates.
  *
  * Usage:
  *   tsx generate-summary.ts
@@ -16,106 +15,167 @@
  *   /tmp/new-version.txt: New monorepo version
  *
  * Output (writes to /tmp for next step):
- *   /tmp/release-summary.txt: Generated release notes
- *   /tmp/used-ai.txt: "true" if AI generated, "false" if template fallback
- *
- * Environment variables:
- *   GITHUB_TOKEN: Required for GitHub Models API authentication
+ *   /tmp/release-summary.txt: Generated release notes from CHANGELOGs
  *
  * Exit codes:
- *   0: Success (AI or fallback summary generated)
+ *   0: Success (summary generated from CHANGELOGs)
  *   1: Error (missing input files, invalid data, etc.)
  */
 
-import { execSync } from 'node:child_process';
-import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 export interface Package {
   name: string;
   version: string;
 }
 
-export type SummaryDepth = 'brief' | 'detailed' | 'comprehensive';
-export type BumpType = 'major' | 'minor' | 'patch';
-
-interface AIResponse {
-  choices: Array<{
-    message: {
-      content: string;
-    };
-  }>;
-}
+export type BumpType = "major" | "minor" | "patch";
 
 /**
- * Determines summary depth based on release significance
- * Pure function - easily testable
+ * Finds the CHANGELOG.md path for a given package
+ * Handles different monorepo structures: packages/, apps/, infrastructure/
+ * Pure function - easily testable with dependency injection
  */
-export function determineSummaryDepth(
-  bumpType: BumpType,
-  packageCount: number
-): SummaryDepth {
-  // Major milestone with multiple packages
-  if (bumpType === 'major' && packageCount >= 2) {
-    return 'comprehensive';
+export function findChangelogPath(
+  packageName: string,
+  repoRoot: string,
+  fileExists: (path: string) => boolean = existsSync,
+): string | null {
+  // Extract package scope and name (e.g., @protomolecule/infrastructure -> infrastructure)
+  const shortName = packageName.includes("/")
+    ? packageName.split("/")[1]
+    : packageName;
+
+  // Special case: infrastructure directory is at repo root, not in packages/
+  if (shortName === "infrastructure") {
+    const infraPath = resolve(repoRoot, "infrastructure", "CHANGELOG.md");
+    if (fileExists(infraPath)) {
+      return infraPath;
+    }
   }
 
-  // Multiple packages or major bump
-  if (bumpType === 'major' || packageCount >= 3) {
-    return 'detailed';
+  // Try common monorepo locations
+  const locations = [
+    resolve(repoRoot, "packages", shortName, "CHANGELOG.md"),
+    resolve(repoRoot, "apps", shortName, "CHANGELOG.md"),
+  ];
+
+  for (const path of locations) {
+    if (fileExists(path)) {
+      return path;
+    }
   }
 
-  // Default for single package, patch/minor
-  return 'brief';
+  return null;
 }
 
 /**
- * Formats packages for display in summary
+ * Extracts version-specific section from CHANGELOG.md
+ * Handles standard changesets format with ## version headers
  * Pure function - easily testable
  */
-export function formatPackageSummary(packages: Package[]): string {
-  return packages.map(pkg => `${pkg.name}@${pkg.version}`).join('\n');
+export function extractChangelogSection(
+  changelogContent: string,
+  version: string,
+): string | null {
+  // Match version header (e.g., "## 4.1.0")
+  const versionHeaderRegex = new RegExp(`^## ${version}$`, "m");
+  const match = changelogContent.match(versionHeaderRegex);
+
+  if (!match || match.index === undefined) {
+    return null;
+  }
+
+  // Find start of this version section
+  const startIndex = match.index;
+
+  // Find next version header (or end of file)
+  const nextVersionRegex = /^## \d+\.\d+\.\d+$/m;
+  const restOfContent = changelogContent.slice(startIndex + match[0].length);
+  const nextMatch = restOfContent.match(nextVersionRegex);
+
+  let endIndex: number;
+  if (nextMatch && nextMatch.index !== undefined) {
+    endIndex = startIndex + match[0].length + nextMatch.index;
+  } else {
+    endIndex = changelogContent.length;
+  }
+
+  // Extract and trim the section
+  return changelogContent.slice(startIndex, endIndex).trim();
 }
 
 /**
- * Generates fallback template summary when AI is unavailable
- * Pure function - easily testable
+ * Generates release summary from CHANGELOG sections
+ * Pure function - easily testable with dependency injection
  */
-export function generateFallbackSummary(packages: Package[]): string {
+export function generateChangelogBasedSummary(
+  packages: Package[],
+  repoRoot: string,
+  fileExists: (path: string) => boolean = existsSync,
+  readFile: (path: string, encoding: BufferEncoding) => string = readFileSync,
+): string {
   let summary = `## Workspace Updates\n\n`;
+
+  // List all published packages
   for (const pkg of packages) {
     summary += `* ${pkg.name}@${pkg.version}\n`;
   }
-  summary += `\n_AI summary unavailable - see individual package changelogs for detailed changes._`;
-  return summary;
+  summary += "\n";
+
+  // Extract CHANGELOG sections for each package
+  for (const pkg of packages) {
+    const changelogPath = findChangelogPath(pkg.name, repoRoot, fileExists);
+
+    if (!changelogPath) {
+      console.log(`⚠️ No CHANGELOG.md found for ${pkg.name}`);
+      continue;
+    }
+
+    try {
+      const changelogContent = readFile(changelogPath, "utf8");
+      const section = extractChangelogSection(changelogContent, pkg.version);
+
+      if (section) {
+        summary += `${section}\n\n`;
+      } else {
+        console.log(
+          `⚠️ Version ${pkg.version} not found in CHANGELOG for ${pkg.name}`,
+        );
+      }
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      console.log(`⚠️ Error reading CHANGELOG for ${pkg.name}:`, errorMessage);
+    }
+  }
+
+  // Add footer if no CHANGELOG sections were found
+  if (
+    summary ===
+    `## Workspace Updates\n\n${packages.map((p) => `* ${p.name}@${p.version}\n`).join("")}\n`
+  ) {
+    summary += `_See individual package changelogs for detailed changes._\n`;
+  }
+
+  return summary.trim();
 }
 
 /**
- * Validates AI response content
- * Pure function - easily testable
- */
-export function validateAIResponse(content: unknown): string {
-  if (!content || typeof content !== 'string') {
-    throw new Error('AI response is empty or not a string');
-  }
-  if (content.length < 10) {
-    throw new Error(`AI response too short: ${content.length} characters`);
-  }
-  if (content.length > 5000) {
-    throw new Error(`AI response too long: ${content.length} characters`);
-  }
-  return content;
-}
-
-/**
- * Main function - generates release summary
+ * Main function - generates release summary from CHANGELOGs
  */
 async function generateSummary(): Promise<void> {
   // Validate required input files exist
   const requiredFiles = [
-    '/tmp/published-packages.json',
-    '/tmp/bump-type.txt',
-    '/tmp/package-count.txt',
-    '/tmp/new-version.txt'
+    "/tmp/published-packages.json",
+    "/tmp/bump-type.txt",
+    "/tmp/package-count.txt",
+    "/tmp/new-version.txt",
   ];
 
   for (const file of requiredFiles) {
@@ -127,136 +187,41 @@ async function generateSummary(): Promise<void> {
 
   // Read data from previous step
   const publishedPackages = JSON.parse(
-    readFileSync('/tmp/published-packages.json', 'utf8')
+    readFileSync("/tmp/published-packages.json", "utf8"),
   ) as Package[];
-  const bumpType = readFileSync('/tmp/bump-type.txt', 'utf8').trim() as BumpType;
+  const bumpType = readFileSync(
+    "/tmp/bump-type.txt",
+    "utf8",
+  ).trim() as BumpType;
   const packageCount = Number.parseInt(
-    readFileSync('/tmp/package-count.txt', 'utf8').trim(),
-    10
+    readFileSync("/tmp/package-count.txt", "utf8").trim(),
+    10,
   );
-  const newVersion = readFileSync('/tmp/new-version.txt', 'utf8').trim();
+  const newVersion = readFileSync("/tmp/new-version.txt", "utf8").trim();
 
-  const depth = determineSummaryDepth(bumpType, packageCount);
+  console.log(
+    `Generating CHANGELOG-based summary for ${packageCount} package(s)`,
+  );
+  console.log(`Bump type: ${bumpType}, New version: ${newVersion}`);
 
-  console.log(`Summary depth: ${depth} (bump: ${bumpType}, packages: ${packageCount})`);
+  // Determine repository root (2 levels up from .github/scripts/)
+  const repoRoot = resolve(__dirname, "..", "..");
 
-  // Build package summary for AI
-  const packageSummary = formatPackageSummary(publishedPackages);
+  // Generate summary from CHANGELOGs
+  const summary = generateChangelogBasedSummary(publishedPackages, repoRoot);
 
-  // Read changesets for context
-  let changesetContext = '';
-  try {
-    // Get the changesets that were just consumed
-    const changesetFiles = execSync('git diff HEAD~1 HEAD --name-only .changeset/*.md', { encoding: 'utf8' });
-    console.log('Changeset files changed:', changesetFiles);
+  // Write output to /tmp
+  writeFileSync("/tmp/release-summary.txt", summary, "utf8");
 
-    // For now, use package names as context
-    changesetContext = publishedPackages.map(pkg => pkg.name).join(', ');
-  } catch (error) {
-    // No changesets found or git command failed - use package names as fallback
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    console.log('Could not read changesets:', errorMessage);
-    console.log('Using package names as context instead');
-    changesetContext = publishedPackages.map(pkg => pkg.name).join(', ');
-  }
-
-  // Prepare AI prompt based on depth
-  const systemPrompt = 'You are generating release notes for a portfolio website monorepo.\n\n' +
-    'Context:\n' +
-    '* This is a multi-app monorepo tracking overall project progress\n' +
-    '* Audience: developers, potential employers, collaborators\n' +
-    '* Tone: Professional but approachable, user-friendly\n' +
-    '* Focus: Impact and benefits, not technical jargon\n\n' +
-    `Generate a ${depth} summary.`;
-
-  let userPrompt = '';
-  if (depth === 'brief') {
-    userPrompt = 'Create a brief one-sentence summary for this release.\n\n' +
-      `Packages published:\n${packageSummary}\n\n` +
-      'Format:\nOne sentence describing the update, then list the packages.';
-  } else if (depth === 'detailed') {
-    userPrompt = 'Create a detailed release summary.\n\n' +
-      `Packages published:\n${packageSummary}\n\n` +
-      `Bump type: ${bumpType}\n\n` +
-      'Format:\n## Summary\nOne paragraph (2-3 sentences) focusing on impact.\n\n' +
-      '## Workspace Updates\n* List each package with brief description\n\n' +
-      '## Highlights\n* 3-5 bullet points with emojis\n* Focus on user-facing value\n\n' +
-      'Use emojis: ✨ 🎨 ⚡ 🧩 📦 🔧 🔄';
-  } else {
-    userPrompt = 'Create a comprehensive release summary for a major milestone.\n\n' +
-      `Packages published:\n${packageSummary}\n\n` +
-      `Bump type: ${bumpType}\n\n` +
-      'This is a significant update. Format:\n## Summary\nTwo paragraphs explaining significance and impact.\n\n' +
-      '## Workspace Updates\nOrganized list with NEW/UPDATED flags where relevant.\n\n' +
-      '## Highlights\n* 5-7 bullet points with emojis covering all aspects\n* Show how pieces fit together\n\n' +
-      "## What's Next\nBrief forward-looking statement (optional).\n\n" +
-      'Use emojis: ✨ 🎨 ⚡ 🧩 📦 🔧 🔄';
-  }
-
-  // Call GitHub Models API
-  // Rate limits: gpt-4o-mini = 150 requests/day, gpt-4o = 50 requests/day
-  // Token limits: GitHub enforces ~8k input / 4k output per request
-  // On rate limit (429), the script falls back to template (no retry needed for releases)
-  let aiSummary = '';
-  let usedAI = false;
-
-  try {
-    console.log('Calling GitHub Models API...');
-
-    const response = await fetch('https://models.inference.ai.azure.com/chat/completions', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${process.env.GITHUB_TOKEN || ''}`,
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        model: 'gpt-4o-mini',
-        messages: [
-          { role: 'system', content: systemPrompt },
-          { role: 'user', content: userPrompt }
-        ],
-        temperature: 0.7,
-        max_tokens: 1000
-      })
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`GitHub Models API error: ${response.status} - ${errorText}`);
-    }
-
-    const data = (await response.json()) as AIResponse;
-    const rawContent = data.choices[0].message.content;
-
-    // Validate AI output using extracted function
-    aiSummary = validateAIResponse(rawContent);
-
-    console.log('✅ AI summary generated successfully');
-    console.log('Summary preview:', aiSummary.substring(0, 200) + '...');
-    usedAI = true;
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    console.log('⚠️ AI generation failed:', errorMessage);
-    console.log('Falling back to template...');
-
-    // Fallback to template using extracted function
-    aiSummary = generateFallbackSummary(publishedPackages);
-    usedAI = false;
-  }
-
-  // Write outputs to /tmp
-  writeFileSync('/tmp/release-summary.txt', aiSummary, 'utf8');
-  writeFileSync('/tmp/used-ai.txt', usedAI ? 'true' : 'false', 'utf8');
-
-  console.log('✅ Release summary generated');
-  console.log(`   AI used: ${usedAI}`);
+  console.log("✅ Release summary generated from CHANGELOGs");
+  console.log("Summary preview:", summary.substring(0, 200) + "...");
 }
 
 // Run the script only if executed directly (not imported)
 if (import.meta.url === `file://${process.argv[1]}`) {
   generateSummary().catch((error) => {
     const errorMessage = error instanceof Error ? error.message : String(error);
-    console.error('❌ ERROR: Failed to generate summary:', errorMessage);
+    console.error("❌ ERROR: Failed to generate summary:", errorMessage);
     process.exit(1);
   });
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,12 +244,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISHED_PACKAGES: ${{ steps.detect_published.outputs.publishedPackages }}
 
-      - name: 🤖 Generate AI Release Summary
+      - name: 📝 Generate Release Summary from CHANGELOGs
         if: steps.detect_published.outputs.published == 'true'
         # Use 'pnpm tsx' not 'tsx' - tsx is in node_modules/.bin, not in PATH
+        # Extracts version-specific sections from package CHANGELOG.md files
         run: pnpm tsx .github/scripts/generate-summary.ts
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🎉 Create Monorepo GitHub Release
         if: steps.detect_published.outputs.published == 'true'
@@ -257,13 +256,8 @@ jobs:
           set -euo pipefail
 
           NEW_VERSION=$(cat /tmp/new-version.txt)
-          USED_AI=$(cat /tmp/used-ai.txt)
 
-          if [[ "$USED_AI" == "true" ]]; then
-            echo "Creating release with AI-generated summary..."
-          else
-            echo "Creating release with template fallback..."
-          fi
+          echo "Creating release with CHANGELOG-based summary..."
 
           # Create GitHub release (skip if already exists)
           if gh release view "v${NEW_VERSION}" &>/dev/null; then


### PR DESCRIPTION
## Summary

Replaces AI-generated release summaries with direct CHANGELOG extraction to eliminate rate limits, simplify workflow, and preserve markdown links.

Closes #269

## Problem

The current release workflow uses GitHub Models API to generate AI summaries, which causes multiple issues:

- ❌ **Rate limits:** 150 requests/day limit
- ❌ **Complex permissions:** Requires `id-token: write` permission  
- ❌ **Token usage:** Unnecessary AI token consumption
- ❌ **Re-writing existing content:** CHANGELOGs already contain all the information
- ❌ **Missing links:** AI summaries don't preserve PR/commit links from changesets

## Solution

Rewrote `generate-summary.ts` to extract release notes directly from package CHANGELOG.md files that changesets automatically generates.

### Implementation

**1. Rewrote generate-summary.ts:**

- Removed all AI/API dependencies
- Added `findChangelogPath()` - locates package CHANGELOGs in packages/, apps/, infrastructure/
- Added `extractChangelogSection()` - extracts version-specific content using regex
- Added `generateChangelogBasedSummary()` - combines all package sections
- Maintained same input/output interface for workflow compatibility

**2. Updated release.yml workflow:**

- Removed `GITHUB_TOKEN` env var from generate-summary step
- Removed `USED_AI` file check
- Updated comments to reflect CHANGELOG-based approach

**3. Added comprehensive tests:**

- 22 tests for new functions (84 total tests across all scripts)
- Tests for CHANGELOG path discovery
- Tests for version section extraction  
- Tests for multi-line content and markdown link preservation
- Tests for fallback behavior

## Benefits

- ✅ **Zero rate limits** - No API calls
- ✅ **Zero tokens** - No AI usage
- ✅ **Faster execution** - Direct file reads vs API calls
- ✅ **More accurate** - Uses exact changeset content with PR/commit links preserved
- ✅ **Simpler maintenance** - No API key management or permission configuration
- ✅ **Better formatting** - Preserves markdown links: [`abc123`](url) and [#42](url)

## Example Output

```markdown
## Workspace Updates

* @robeasthope/eslint-config@4.1.0
* @protomolecule/infrastructure@2.1.0

## 4.1.0

### Minor Changes

- [`7d563c1`](https://github.com/RobEasthope/protomolecule/commit/...) [#266](https://github.com/RobEasthope/protomolecule/pull/266) - Add common import ignore patterns...

## 2.1.0

### Minor Changes

- [`abc1234`](https://github.com/RobEasthope/protomolecule/commit/...) - Update build configuration...
```

## Files Modified

- `.github/scripts/generate-summary.ts` - Complete rewrite
- `.github/scripts/generate-summary.test.ts` - New tests for CHANGELOG extraction
- `.github/workflows/release.yml` - Removed AI/token references

## Testing

✅ All 84 tests passing
✅ Tests cover all new functions
✅ Tests verify markdown link preservation
✅ Tests verify fallback behavior

## Changeset

✅ Created changeset for `@protomolecule/infrastructure` (minor)