### PR TITLE
fix(infrastructure): configure npm provenance at package level for OIDC publishing

### DIFF
--- a/.changeset/fix-npm-oidc-provenance.md
+++ b/.changeset/fix-npm-oidc-provenance.md
@@ -1,0 +1,43 @@
+---
+"@protomolecule/infrastructure": patch
+---
+
+Fix npm OIDC publishing by configuring provenance at package level
+
+**Problem:**
+The `changesets/action` was overwriting our `.npmrc` configuration, causing `ENEEDAUTH` errors when attempting to publish with OIDC trusted publishers.
+
+**Root Cause:**
+We were trying to configure npm registry settings via a workflow step that created `.npmrc`, but the changesets action detects this file doesn't have user-specific auth and replaces it with its own version, throwing away our configuration.
+
+**Solution:**
+Following the approach recommended in changesets issue #1152, we now configure provenance directly in each package's `package.json`:
+
+```json
+{
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}
+```
+
+This enables npm CLI to:
+
+1. Automatically use OIDC authentication when `id-token: write` permission is present
+2. Generate provenance attestations for published packages
+3. Work correctly with changesets/action without requiring `.npmrc` manipulation
+
+**Changes:**
+
+- ✅ Added `provenance: true` to all published packages (ui, eslint-config, colours, markdownlint-config)
+- ✅ Removed `.npmrc` configuration step from workflow
+- ✅ Removed `--provenance` flag from publish command (now configured per-package)
+
+**Benefits:**
+
+- Packages will publish with cryptographic provenance attestations
+- Supply chain security improved with verifiable build provenance
+- npm package pages will show green checkmarks for verified builds
+
+Related to #291 (npm OIDC migration)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,21 +156,13 @@ jobs:
 
           echo "" >> $GITHUB_STEP_SUMMARY
 
-      - name: 🔐 Configure npm for OIDC Publishing
-        run: |
-          # For OIDC trusted publishers, npm doesn't need a traditional auth token
-          # The --provenance flag triggers OIDC authentication automatically
-          # We just need to ensure we're pointing to the correct registry
-          echo "registry=https://registry.npmjs.org/" > .npmrc
-          echo "✅ npm configured for OIDC trusted publishers"
-
       - name: 🚀 Create Release or Publish
         id: changesets
         uses: changesets/action@v1.5.3
         with:
           # This will run pnpm changeset version && pnpm changeset publish
-          # --provenance flag enables supply chain attestations via OIDC
-          publish: pnpm changeset publish --provenance
+          # Provenance is enabled via publishConfig.provenance in package.json
+          publish: pnpm changeset publish
           # Commit message for version updates
           commit: "release: version packages for release"
           # Title for version update PRs - will be enhanced in next step

--- a/packages/colours/package.json
+++ b/packages/colours/package.json
@@ -44,6 +44,7 @@
     "rimraf": "^6.0.1"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -81,6 +81,7 @@
     "eslint": "^8.57.0 || ^9.0.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/markdownlint-config/package.json
+++ b/packages/markdownlint-config/package.json
@@ -41,6 +41,7 @@
     "rimraf": "^6.0.1"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -111,6 +111,7 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }


### PR DESCRIPTION
## Summary

Fixes npm OIDC publishing by configuring provenance attestations directly in `package.json` instead of via workflow configuration. This resolves the `ENEEDAUTH` errors that were occurring because `changesets/action` was overwriting our `.npmrc` configuration.

## Problem

After migrating to npm OIDC trusted publishers (PR #291), the release workflow was failing with:

```
ENEEDAUTH This command requires you to be logged in to https://registry.npmjs.org
You need to authorize this machine using `npm adduser`
```

**Root Cause:** We were creating `.npmrc` in a workflow step, but the `changesets/action` detects this file doesn't have user-specific authentication and replaces it with its own version, throwing away our registry configuration.

## Solution

Following the approach recommended in [changesets issue #1152](https://github.com/changesets/changesets/issues/1152), we now configure provenance directly in each package's `package.json`:

```json
{
  "publishConfig": {
    "access": "public",
    "provenance": true
  }
}
```

This enables npm CLI to:
1. Automatically use OIDC authentication when `id-token: write` permission is present
2. Generate provenance attestations for published packages  
3. Work correctly with `changesets/action` without requiring `.npmrc` manipulation

## Changes

- ✅ Added `provenance: true` to all published packages:
  - `@robeasthope/ui`
  - `@robeasthope/eslint-config`
  - `@robeasthope/colours`
  - `@robeasthope/markdownlint-config`
- ✅ Removed `.npmrc` configuration step from workflow
- ✅ Removed `--provenance` flag from publish command (now configured per-package)

## Benefits

- **Supply chain security**: Packages will publish with cryptographic provenance attestations
- **Verifiable builds**: npm package pages will show green checkmarks for verified builds
- **No token management**: OIDC tokens are short-lived and automatic
- **Audit trail**: npm knows exactly which workflow published which package

## Testing

The changeset for `@robeasthope/eslint-config@5.2.0` is still pending from the previous release attempt. Merging this PR will trigger another release attempt that should succeed with the corrected configuration.

## Related

- Closes failed workflow: https://github.com/RobEasthope/protomolecule/actions/runs/18489142854
- Related to #291 (npm OIDC migration planning)
- Follows guidance from: https://github.com/changesets/changesets/issues/1152

🤖 Generated with [Claude Code](https://claude.com/claude-code)