### PR TITLE
ci(workflows): optimize e2e testing to run only on UI changes

### DIFF
--- a/.changeset/optimize-e2e-workflow.md
+++ b/.changeset/optimize-e2e-workflow.md
@@ -1,0 +1,19 @@
+---
+"@protomolecule/infrastructure": patch
+---
+
+Optimize E2E testing workflow to run only when necessary
+
+**Changes:**
+
+- Remove push trigger - workflow now only runs on pull requests
+- Add path filtering to skip when UI package is unchanged
+- Prevents unnecessary CI runs on release automation commits
+
+**Benefits:**
+
+- Reduces GitHub Actions minutes usage
+- Faster PR feedback (no queuing for irrelevant changes)
+- Matches pattern used in linting-and-testing workflow
+
+Closes #308

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -2,8 +2,11 @@ name: E2E Testing
 
 on:
   pull_request:
-  push:
-    branches: [main]
+    paths:
+      # Run when UI package changes
+      - 'packages/ui/**'
+      # Run when workflow changes
+      - '.github/workflows/e2e-testing.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Optimizes the E2E testing workflow to run only when necessary, reducing CI minutes and improving PR feedback speed.

### Changes

- ✅ **Removed push trigger** - Workflow no longer runs on pushes to main (including release automation)
- ✅ **Added path filtering** - Only triggers when `packages/ui/**` changes
- ✅ **Simplified pattern** - Matches approach used in `linting-and-testing.yml`

### Problem Solved

Previously, the E2E workflow ran:
- ❌ On **every push to main** (including release automation commits like `chore: bump monorepo`)
- ❌ On **all pull requests** regardless of changed files
- 📊 Example: [Run #249](https://github.com/RobEasthope/protomolecule/actions/runs/18491683721) wasted CI minutes on a version bump

### Benefits

- 🚀 **Reduces unnecessary CI runs** - Only runs when UI package changes
- 💰 **Saves GitHub Actions minutes** - No more runs on infrastructure/docs PRs
- ⚡ **Faster feedback** - Workflow won't queue when irrelevant
- 🎯 **Better signal** - E2E results only appear when they matter

### Testing

The workflow will now:
- ✅ Run on PRs that modify `packages/ui/**`
- ✅ Run when the workflow file itself changes
- ✅ Skip on PRs that only touch other packages, docs, or infrastructure
- ✅ Skip on release automation commits to main

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)