### PR TITLE
feat(github-rulesets): simplify main branch protection rules

### DIFF
--- a/.changeset/lockdown-main-branch.md
+++ b/.changeset/lockdown-main-branch.md
@@ -1,12 +1,22 @@
 ---
-"@robeasthope/github-rulesets": patch
+"@robeasthope/github-rulesets": minor
 ---
 
-Simplify main branch protection rules
+Split and simplify main branch protection into two rulesets
+
+**Protect production ruleset** (minimal enforcement):
 
 - Add `creation` rule: Blocks branch creation (prevents recreating main)
 - Add `update` rule: Blocks all direct pushes from local machines
 - Remove required status checks (Lint, Build, Test, Changeset Check)
-- Keep PR review requirement (1 approving review)
+- Remove review requirements - only requires PR creation
+- CI checks will run and surface failures without blocking merges
 
-All changes to main must now go through pull requests with review approval.
+**Require PR review ruleset** (optional, for stricter enforcement):
+
+- New standalone ruleset for teams wanting review requirements
+- Requires 1 approving review before merge
+- Dismisses stale reviews on push
+- Requires review thread resolution
+
+This split allows teams to choose their enforcement level: basic PR workflow (shows CI results) or full review requirement.

--- a/packages/github-rulesets/rulesets/Protect production ruleset.json
+++ b/packages/github-rulesets/rulesets/Protect production ruleset.json
@@ -25,13 +25,6 @@
       "type": "required_linear_history"
     },
     {
-      "parameters": {
-        "dismiss_stale_reviews_on_push": true,
-        "require_code_owner_review": false,
-        "require_last_push_approval": false,
-        "required_approving_review_count": 1,
-        "required_review_thread_resolution": true
-      },
       "type": "pull_request"
     }
   ],

--- a/packages/github-rulesets/rulesets/Require PR review ruleset.json
+++ b/packages/github-rulesets/rulesets/Require PR review ruleset.json
@@ -1,0 +1,24 @@
+{
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": ["~DEFAULT_BRANCH"]
+    }
+  },
+  "enforcement": "active",
+  "name": "Require PR review",
+  "rules": [
+    {
+      "parameters": {
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 1,
+        "required_review_thread_resolution": true
+      },
+      "type": "pull_request"
+    }
+  ],
+  "target": "branch"
+}


### PR DESCRIPTION
## Summary

Splits the main branch protection into **two separate rulesets** to provide flexibility in enforcement levels:

### 🔓 Protect production ruleset (minimal enforcement)
**File**: `Protect production ruleset.json`

- ✅ Add `creation` rule: Blocks branch creation (prevents recreating main)
- ✅ Add `update` rule: Blocks all direct pushes from local machines
- ✅ Remove required status checks (Lint, Build, Test, Changeset Check)
- ✅ **Remove review requirements** - only requires PR creation
- ✅ CI checks will run and **surface failures without blocking merges**

### 🔒 Require PR review ruleset (optional, stricter enforcement)
**File**: `Require PR review ruleset.json` *(NEW)*

- ✅ Requires 1 approving review before merge
- ✅ Dismisses stale reviews on push
- ✅ Requires review thread resolution
- ✅ Fully portable - no hardcoded IDs

### 📦 ESLint Config (@robeasthope/eslint-config)
- ✅ Relax `func-style` rule from error to warn
- ✅ Allow both function declarations and expressions

## Key Benefits

**Flexibility**: Teams can choose their enforcement level:
- **Basic**: Use "Protect production" alone for PR workflow with CI visibility (no blocking)
- **Strict**: Add "Require PR review" for human approval requirement

**Portability**: Both rulesets use `~DEFAULT_BRANCH` and have no repo-specific IDs. Import into any GitHub repository without modification.

**CI Visibility Without Blocking**: The minimal ruleset ensures all changes go through PRs where CI runs and shows results, but won't prevent merging if checks fail. Perfect for avoiding CI bottlenecks while maintaining visibility.

## What Changed

**Before**: Single ruleset with review + status check requirements
**After**: Two rulesets - basic PR requirement (no reviews) + optional review enforcement

## Test Plan

- [ ] Apply "Protect production" ruleset to test repository
- [ ] Verify direct push is blocked: `git push origin main`
- [ ] Verify PR can be created and merged without review
- [ ] Verify CI checks run but don't block merge
- [ ] Apply "Require PR review" ruleset and verify review is required
- [ ] Confirm `~DEFAULT_BRANCH` resolves correctly in both rulesets

🤖 Generated with [Claude Code](https://claude.com/claude-code)