### PR TITLE
fix(github-rulesets): allow GitHub Actions to bypass Protect production rules

### DIFF
--- a/.changeset/allow-github-actions-bypass.md
+++ b/.changeset/allow-github-actions-bypass.md
@@ -2,21 +2,28 @@
 "@robeasthope/github-rulesets": patch
 ---
 
-Allow GitHub Actions to bypass Protect production ruleset
+Allow GitHub Actions to bypass Protect production ruleset and simplify rules
 
-Adds GitHub Actions (integration_id: 15368) as a bypass actor to allow CI/CD workflows to push version bump commits directly to the default branch during releases.
+**Changes:**
 
-**What changed:**
+- Add `bypass_actors` with GitHub Actions integration (actor_id: 15368)
+- Remove `required_linear_history` rule for flexibility with merge strategies
+- Maintain all core protection rules
 
-- Add `bypass_actors` with GitHub Actions integration
-- Enables automated release workflow to function
+**What this enables:**
+
+- GitHub Actions can push version bump commits during releases
+- Automated release workflow (`changesets/action`) functions properly
+- Supports both merge commits and squash/rebase strategies
 - Human developers still blocked from direct pushes
 
 **Why this is needed:**
-The `update` rule blocks ALL direct pushes to main, including automated CI/CD workflows. This change allows the release workflow (`changesets/action`) to push version bump commits while maintaining protection against manual developer pushes.
+
+The `update` rule blocks ALL direct pushes to main, including automated CI/CD workflows. This change allows the release workflow to push version bump commits while maintaining protection against manual developer pushes.
 
 **Security:**
 
 - Only workflows running from repository branches can bypass
 - External forks cannot trigger bypass-enabled workflows
 - `RELEASE_PAT` token still requires proper permissions
+- Core protections remain: creation, update, deletion, non_fast_forward, pull_request

--- a/packages/github-rulesets/rulesets/Protect production ruleset.json
+++ b/packages/github-rulesets/rulesets/Protect production ruleset.json
@@ -1,7 +1,7 @@
 {
   "bypass_actors": [
     {
-      "actor_id": 1,
+      "actor_id": 15368,
       "actor_type": "Integration",
       "bypass_mode": "always"
     }


### PR DESCRIPTION
## Summary

Fixes the release workflow by allowing GitHub Actions to bypass the `Protect production` ruleset and simplifies branch protection rules.

## Changes Made

### 1. ✅ Add GitHub Actions Bypass Actor
```json
"bypass_actors": [
  {
    "actor_id": 15368,
    "actor_type": "Integration",
    "bypass_mode": "always"
  }
]
```

- **actor_id: 15368** - GitHub Actions built-in integration (universal across all repos)
- **actor_type: "Integration"** - Specifies it's a GitHub App
- **bypass_mode: "always"** - Can bypass in all contexts (required for direct commits)

### 2. ✅ Remove `required_linear_history` Rule

Removed the linear history requirement to provide flexibility in merge strategies:
- Allows merge commits, squash merging, and rebase merging
- No longer forces specific Git history patterns
- Teams can choose their preferred merge strategy

## Problem Solved

After merging PR #312, the `update` rule blocked **ALL** direct pushes to main, including automated CI/CD workflows. This caused the release workflow to fail when `changesets/action` tries to push version bump commits:

```yaml
# release.yml line 167
commit: "release: version packages for release"
```

Without a bypass actor, even the `RELEASE_PAT` token cannot push to main because the ruleset applies to all actors.

## Impact

✅ **Release workflow unblocked** - Can now push version bump commits  
✅ **Human developers still protected** - Direct pushes from local machines remain blocked  
✅ **Flexible merge strategies** - No longer restricted to linear history  
✅ **Secure by design** - Only workflows running from repository branches can bypass (external forks cannot)

## What Still Blocks Humans

The `update` rule continues to prevent:
- ❌ `git push origin main` from developer machines
- ❌ Direct commits to main locally
- ❌ Any manual push attempts

## Remaining Protection Rules

After these changes, the ruleset enforces:
1. **`creation`** - Blocks branch recreation
2. **`update`** - Blocks direct pushes (except GitHub Actions)
3. **`deletion`** - Blocks branch deletion
4. **`non_fast_forward`** - Blocks force pushes
5. **`pull_request`** - Requires PR workflow (no review requirement)

## Security Notes

- Only workflows running **from branches in this repository** can use the bypass
- External PRs from forks **cannot** trigger workflows with bypass permissions
- The `RELEASE_PAT` token still requires proper repository permissions
- This is the standard pattern for automated release workflows with branch protection
- `actor_id: 15368` is the universal GitHub Actions integration ID (same across all repositories)

## Commit History

**Fixed in latest commit:**
- ❌ Previous commit incorrectly changed actor_id from 15368 to 1
- ❌ Another commit removed bypass_actors entirely
- ✅ Corrected to use actor_id: 15368 (GitHub Actions official ID)

## Test Plan

- [ ] Merge this PR to main
- [ ] Trigger a release by merging a changeset PR
- [ ] Verify release workflow completes successfully
- [ ] Verify version bump commit is pushed to main
- [ ] Verify human `git push origin main` is still blocked
- [ ] Test merge commit and squash merge strategies work

## Related

- Fixes issue introduced in PR #312
- References: `packages/github-rulesets/rulesets/Protect production ruleset.json`
- References: `.github/workflows/release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)