### PR TITLE
feat(eslint-config)!: enforce function declarations with error-level func-style rule

### DIFF
--- a/.changeset/enforce-func-style-declarations.md
+++ b/.changeset/enforce-func-style-declarations.md
@@ -1,0 +1,39 @@
+---
+"@robeasthope/eslint-config": minor
+---
+
+Enforce function declarations with error-level func-style rule
+
+**Breaking Change for Consumers:**
+The `func-style` rule now errors (previously warned) when arrow functions or function expressions are used instead of function declarations. This enforces consistent function declaration style across codebases.
+
+**Changes:**
+
+- Changed `func-style` from `"warn"` to `"error"` severity
+- Function declarations are now the enforced standard pattern
+- Arrow functions and function expressions will cause linting failures
+
+**Migration Guide:**
+Convert arrow functions and function expressions to function declarations:
+
+```typescript
+// ❌ Before (now errors)
+const myFunction = () => {
+  // ...
+}
+
+// ✅ After
+function myFunction() {
+  // ...
+}
+```
+
+**Framework-Specific Exceptions:**
+React Router 7 files (`root.tsx`, `*route.tsx`) will need special handling in a future update, as they require arrow functions for typed exports like `export const links: Route.LinksFunction = () => [...]`. See issue #323 for tracking.
+
+**Rationale:**
+
+- Better hoisting behavior
+- Clearer stack traces in debugging
+- Explicit function names in all contexts
+- Consistent codebase style

--- a/packages/eslint-config/rules/preferences.ts
+++ b/packages/eslint-config/rules/preferences.ts
@@ -12,10 +12,11 @@ export const preferences = {
   rules: {
     "canonical/filename-match-regex": "off",
     "canonical/id-match": "off",
-    // Allow arrow functions for exported const with type annotations (React Router v7, Remix patterns)
-    // e.g., `export const links: Route.LinksFunction = () => [...]`
+    // Enforce function declarations as the standard pattern
+    // Arrow functions and function expressions will error
+    // Note: React Router 7 files (root.tsx, *route.tsx) need framework-specific exceptions
     // See: https://github.com/RobEasthope/protomolecule/issues/299
-    "func-style": ["warn", "declaration"],
+    "func-style": ["error", "declaration"],
     "import/no-extraneous-dependencies": [
       "error",
       {


### PR DESCRIPTION
## Summary

Enforces function declarations as the standard pattern by upgrading the `func-style` ESLint rule from warning to error severity. This breaking change ensures consistent function declaration style across all codebases using this config.

## Changes

- **func-style rule**: Changed from `"warn"` to `"error"` in `packages/eslint-config/rules/preferences.ts:19`
- **Enforcement**: Function declarations are now required; arrow functions and function expressions will cause CI failures
- **Documentation**: Updated comments to note framework-specific exceptions needed

## Breaking Change

**Before (allowed with warning):**
```typescript
const myFunction = () => {
  // ...
}
```

**After (required, errors otherwise):**
```typescript
function myFunction() {
  // ...
}
```

## Migration Guide for Consumers

Update code to use function declarations:
```typescript
// ❌ Arrow function (now errors)
const calculateTotal = (items) => { ... }

// ✅ Function declaration (required)
function calculateTotal(items) { ... }
```

## Framework-Specific Considerations

React Router 7 files (`root.tsx`, `*route.tsx`) will need framework-specific exceptions in a follow-up PR, as they require arrow functions for typed exports:

```typescript
export const links: Route.LinksFunction = () => [...]
```

See issue #323 for tracking this work.

## Benefits

- ✅ Better hoisting behavior
- ✅ Clearer stack traces in debugging  
- ✅ Explicit function names in all contexts
- ✅ Consistent codebase style enforcement via CI

## Test Plan

- [x] Built eslint-config package successfully
- [x] Ran monorepo-wide linting - all tests passed
- [x] Created changeset for minor version bump
- [x] Created follow-up issue #323 for framework exceptions

## Related Issues

- Closes: N/A (new enforcement)
- Related: #323 (React Router 7 framework exceptions)
- Related: #299 (Original React Router v7 patterns discussion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)