### PR TITLE
feat(eslint-config): add React Router 7 exceptions for func-style rule

### DIFF
--- a/.changeset/react-router-func-style-exceptions.md
+++ b/.changeset/react-router-func-style-exceptions.md
@@ -1,0 +1,34 @@
+---
+"@robeasthope/eslint-config": patch
+---
+
+Add React Router 7 exceptions for func-style rule
+
+**Changes:**
+
+- Created `reactRouterExceptions` config for React Router 7 files (`root.tsx`, `*.route.tsx`)
+- These files now allow arrow functions via `allowArrowFunctions` option
+- Exceptions properly override the strict func-style enforcement from base config
+
+**React Router 7 Patterns Now Allowed:**
+```typescript
+// ✅ Allowed in root.tsx and *.route.tsx files
+export const links: Route.LinksFunction = () => [...];
+export const meta: Route.MetaFunction = () => ({ ... });
+export const loader: Route.LoaderFunction = async () => { ... };
+```
+
+**Why This Exception Is Needed:**
+React Router 7 uses typed exports that require arrow functions or function expressions because:
+
+1. They need type annotations (`Route.LinksFunction`, etc.)
+2. TypeScript doesn't allow type annotations on function declarations
+3. The framework expects these specific export patterns
+
+**Implementation Details:**
+
+- Created `rules/reactRouterExceptions.ts` with framework-specific overrides
+- Added to config array AFTER `preferences` (order matters for override behavior)
+- Uses `allowArrowFunctions: true` option to permit arrow functions in variable declarations
+
+**Resolves:** #323

--- a/packages/eslint-config/index.ts
+++ b/packages/eslint-config/index.ts
@@ -6,6 +6,7 @@ import { frameworkRouting } from "./rules/frameworkRouting";
 import { ignoredFileAndFolders } from "./rules/ignoredFileAndFolders";
 import { packageJson } from "./rules/packageJson";
 import { preferences } from "./rules/preferences";
+import { reactRouterExceptions } from "./rules/reactRouterExceptions";
 import { storybook } from "./rules/storybook";
 import { testFiles } from "./rules/testFiles";
 import { typescriptOverrides } from "./rules/typescriptOverrides";
@@ -32,6 +33,9 @@ const config: any[] = [
   testFiles,
   ...astro,
   preferences,
+  // React Router 7 exceptions MUST come after preferences to override func-style
+  // See: https://github.com/RobEasthope/protomolecule/issues/323
+  reactRouterExceptions,
   frameworkRouting,
 ];
 

--- a/packages/eslint-config/rules/reactRouterExceptions.ts
+++ b/packages/eslint-config/rules/reactRouterExceptions.ts
@@ -1,0 +1,23 @@
+import { type Linter } from "eslint";
+
+export const reactRouterExceptions = {
+  files: ["**/root.tsx", "**/*.route.tsx"],
+  rules: {
+    // Allow arrow functions for React Router 7 typed exports
+    // React Router 7 uses patterns like:
+    //   export const links: Route.LinksFunction = () => [...]
+    //   export const meta: Route.MetaFunction = () => ({ ... })
+    //   export const loader: Route.LoaderFunction = async () => { ... }
+    //
+    // These MUST be arrow functions or function expressions because:
+    // 1. They require type annotations (Route.LinksFunction, etc.)
+    // 2. TypeScript doesn't allow type annotations on function declarations
+    // 3. The framework expects these specific export patterns
+    //
+    // The allowArrowFunctions option permits arrow functions in variable
+    // declarations while still enforcing function declarations elsewhere
+    //
+    // See: https://github.com/RobEasthope/protomolecule/issues/323
+    "func-style": ["error", "declaration", { allowArrowFunctions: true }],
+  },
+} satisfies Linter.Config;


### PR DESCRIPTION
## Summary

Adds framework-specific exceptions to allow arrow functions in React Router 7 files (`root.tsx`, `*.route.tsx`) while maintaining strict function declaration enforcement in all other files.

## Changes

### New File: `rules/reactRouterExceptions.ts`
- Created dedicated config for React Router 7 file patterns
- Uses `allowArrowFunctions: true` option to permit arrow functions in variable declarations
- Comprehensive documentation explaining why these exceptions are needed

### Updated: `index.ts`
- Imported `reactRouterExceptions` config
- Added to config array **after** `preferences` (order is critical for override behavior)
- Includes comment explaining the ordering requirement

## React Router 7 Patterns Now Supported

```typescript
// ✅ Now allowed in root.tsx and *.route.tsx files
export const links: Route.LinksFunction = () => [
  { rel: "stylesheet", href: "/styles.css" }
];

export const meta: Route.MetaFunction = () => ({
  title: "My Page"
});

export const loader: Route.LoaderFunction = async () => {
  return { data: "test" };
};
```

## Why This Exception Is Needed

React Router 7 requires arrow functions for typed exports because:

1. **Type annotations required**: Framework uses `Route.LinksFunction`, `Route.MetaFunction`, etc.
2. **TypeScript limitation**: Type annotations aren't allowed on function declarations
3. **Framework convention**: React Router 7 documentation shows these patterns

**Example of the problem:**
```typescript
// ❌ Can't do this - TypeScript doesn't allow it
export function links(): LinkDescriptor[] {
  return [...];
}

// ✅ Must use this pattern instead
export const links: Route.LinksFunction = () => [...];
```

## Implementation Details

### Config Override Order
The `reactRouterExceptions` must come **after** `preferences` in the config array because ESLint flat config uses "last match wins" behavior. This allows the exception to properly override the strict enforcement.

### File Pattern Matching
- `**/root.tsx` - Catches React Router 7 root files at any depth
- `**/*.route.tsx` - Catches all React Router 7 route files (e.g., `home.route.tsx`)

### allowArrowFunctions Option
The ESLint `func-style` rule's `allowArrowFunctions: true` option permits arrow functions in variable declarations while still enforcing function declarations for standalone functions.

## Testing

- [x] Built eslint-config package successfully
- [x] Package linting passes
- [x] Created comprehensive changeset documentation
- [x] Verified config ordering in array
- [x] Confirmed TypeScript compilation succeeds

## Resolves

Closes #323

## Related

- Built on top of PR #324 (func-style enforcement)
- Related to issue #299 (React Router v7 patterns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)