### PR TITLE
feat(eslint-config)!: switch to top-level type imports for React Router 7 compatibility

### DIFF
--- a/.changeset/prefer-top-level-type-imports.md
+++ b/.changeset/prefer-top-level-type-imports.md
@@ -1,0 +1,102 @@
+---
+"@robeasthope/eslint-config": major
+---
+
+**BREAKING CHANGE: Switch to top-level type imports for React Router 7 compatibility**
+
+This change updates the default type import style from inline (`import { type Foo }`) to top-level (`import type { Foo }`). This ensures compatibility with React Router 7's virtual module system and TypeScript's `verbatimModuleSyntax` option.
+
+## What Changed
+
+### Import Style Rules
+
+- **Disabled**: `canonical/prefer-inline-type-import`
+- **Changed**: `import/consistent-type-specifier-style` from `"prefer-inline"` to `"prefer-top-level"`
+- **Updated**: `import/no-duplicates` with `{ "prefer-inline": false }`
+
+### Before (v5.x - Inline Style)
+
+```typescript
+import { useState, type FC } from "react";
+```
+
+### After (v6.0.0 - Top-Level Style)
+
+```typescript
+import type { FC } from "react";
+import { useState } from "react";
+```
+
+## Why This Change?
+
+React Router 7 generates virtual type modules (e.g., `./+types/route`) that fail to resolve with inline type imports during production builds. Top-level type imports are:
+
+1. **Compatible with all frameworks** - Works with React Router 7, Remix, Next.js, and others
+2. **Safer with verbatimModuleSyntax** - Aligns with TypeScript's strict module resolution
+3. **More explicit** - Clear separation between type and value imports
+4. **Future-proof** - Less likely to conflict with framework-specific module systems
+
+## Migration Guide
+
+Run `pnpm lint:fix` in your project. Most inline type imports will auto-fix to top-level:
+
+```bash
+pnpm lint:fix
+```
+
+### Manual Fixes Required
+
+For mixed imports (types + values from same module), you'll need to split them manually:
+
+```typescript
+// Before
+import { useState, type FC, type ReactNode } from "react";
+
+// After
+import type { FC, ReactNode } from "react";
+import { useState } from "react";
+```
+
+### Projects Using React Router 7
+
+If you previously overrode these rules for React Router compatibility, you can now **remove the overrides**:
+
+```typescript
+// eslint.config.ts - Remove this override
+{
+  files: ["app/**/*.{ts,tsx}"],
+  rules: {
+    "import/consistent-type-specifier-style": ["error", "prefer-top-level"], // ❌ Remove
+    "canonical/prefer-inline-type-import": "off", // ❌ Remove
+    "import/no-duplicates": ["error", { "prefer-inline": false }], // ❌ Remove
+  },
+}
+```
+
+## Breaking Changes
+
+### Style Enforcement
+
+- Projects using inline type imports will see lint errors
+- `lint:fix` will convert inline imports to top-level
+- Separate import statements for types and values are now the standard
+
+### No Impact On
+
+- Runtime behavior (type imports are erased at compile time)
+- Type safety
+- Import functionality
+
+## Affected Projects
+
+This change specifically addresses issues in:
+
+- Waterleaf monorepo (#91)
+- Hecate monorepo (#302)
+- Any project using React Router 7 with virtual type modules
+
+## References
+
+- Issue: https://github.com/RobEasthope/protomolecule/issues/333
+- React Router Issue: https://github.com/remix-run/react-router/issues/12503
+- TypeScript verbatimModuleSyntax: https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -12,13 +12,51 @@ pnpm add -D @robeasthope/eslint-config eslint
 
 That's it! All ESLint plugins are bundled as dependencies, so you don't need to install them separately.
 
+### Migrating from v5.x
+
+**v6.0.0 introduces a breaking change**: Type import style has changed from inline to top-level for React Router 7 compatibility.
+
+```bash
+# Update to v6.0.0
+pnpm update @robeasthope/eslint-config@6.0.0
+
+# Auto-fix most import style changes
+pnpm lint:fix
+```
+
+**What changed:**
+
+```typescript
+// Before (v5.x - Inline Style)
+import { useState, type FC } from "react";
+
+// After (v6.0.0 - Top-Level Style)
+import type { FC } from "react";
+import { useState } from "react";
+```
+
+**Manual fixes required** for mixed imports:
+
+```typescript
+// Before
+import { useState, type FC, type ReactNode } from "react";
+
+// After - Split manually
+import type { FC, ReactNode } from "react";
+import { useState } from "react";
+```
+
+**If you overrode import rules for React Router 7**, you can now remove those overrides as they're built-in.
+
+See the [full migration guide](https://github.com/RobEasthope/protomolecule/issues/333) for details.
+
 ### Migrating from v4.x
 
 If you're upgrading from v4.x, you can remove the plugin dependencies:
 
 ```bash
-# Update to v5.0.0
-pnpm update @robeasthope/eslint-config@5.0.0
+# Update to v5.0.0+
+pnpm update @robeasthope/eslint-config
 
 # Remove plugin dependencies (now bundled)
 pnpm remove astro-eslint-parser eslint-plugin-import-x \
@@ -54,6 +92,7 @@ This configuration includes:
 
 - **TypeScript Support**: Full TypeScript linting with type checking
 - **React Support**: React and JSX best practices
+- **React Router 7 Compatible**: Top-level type imports for virtual module compatibility
 - **Modern JavaScript**: ES2022+ features
 - **Code Quality**: Enforces consistent code style
 - **Accessibility**: Basic a11y checks for React components
@@ -71,6 +110,7 @@ This configuration includes:
 
 - Strict TypeScript checking
 - React 19 compatible rules
+- **Top-level type imports** (`import type { }` instead of `import { type }`)
 - Consistent import ordering
 - No unused variables or imports
 - Consistent naming conventions

--- a/packages/eslint-config/rules/astro.ts
+++ b/packages/eslint-config/rules/astro.ts
@@ -1,4 +1,4 @@
-import { type Linter } from "eslint";
+import type { Linter } from "eslint";
 import { configs } from "eslint-plugin-astro";
 
 export const astro = [

--- a/packages/eslint-config/rules/commonjs.ts
+++ b/packages/eslint-config/rules/commonjs.ts
@@ -1,4 +1,4 @@
-import { type Linter } from "eslint";
+import type { Linter } from "eslint";
 import globals from "globals";
 
 export const commonjs = {

--- a/packages/eslint-config/rules/frameworkRouting.ts
+++ b/packages/eslint-config/rules/frameworkRouting.ts
@@ -1,4 +1,4 @@
-import { type Linter } from "eslint";
+import type { Linter } from "eslint";
 
 /**
  * ESLint configuration for framework-based file routing patterns.

--- a/packages/eslint-config/rules/ignoredFileAndFolders.ts
+++ b/packages/eslint-config/rules/ignoredFileAndFolders.ts
@@ -1,4 +1,4 @@
-import { type Linter } from "eslint";
+import type { Linter } from "eslint";
 
 export const ignoredFileAndFolders = {
   ignores: [

--- a/packages/eslint-config/rules/packageJson.ts
+++ b/packages/eslint-config/rules/packageJson.ts
@@ -1,4 +1,4 @@
-import { type Linter } from "eslint";
+import type { Linter } from "eslint";
 
 export const packageJson = {
   files: ["**/package.json"],

--- a/packages/eslint-config/rules/preferences.ts
+++ b/packages/eslint-config/rules/preferences.ts
@@ -1,4 +1,4 @@
-import { type Linter } from "eslint";
+import type { Linter } from "eslint";
 
 export const preferences = {
   files: ["**/*.{ts,tsx,js,jsx,mjs}"],
@@ -12,11 +12,25 @@ export const preferences = {
   rules: {
     "canonical/filename-match-regex": "off",
     "canonical/id-match": "off",
+    // Prefer top-level type imports for React Router 7 compatibility
+    // Top-level: import type { Foo } from 'bar'
+    // Inline: import { type Foo } from 'bar' (causes issues with virtual modules)
+    // See: https://github.com/RobEasthope/protomolecule/issues/333
+    "canonical/prefer-inline-type-import": "off",
     // Enforce function declarations as the standard pattern
     // Arrow functions and function expressions will error
     // Note: React Router 7 files (root.tsx, *route.tsx) need framework-specific exceptions
     // See: https://github.com/RobEasthope/protomolecule/issues/299
     "func-style": ["error", "declaration"],
+    // Prefer top-level type imports over inline type imports
+    // This ensures compatibility with React Router 7 virtual modules and verbatimModuleSyntax
+    // See: https://github.com/RobEasthope/protomolecule/issues/333
+    "import/consistent-type-specifier-style": ["error", "prefer-top-level"],
+    // Prevent duplicate imports from the same module
+    // With prefer-inline: false, allows separate type and value imports
+    // e.g., import { useState } from 'react' and import type { FC } from 'react'
+    // See: https://github.com/RobEasthope/protomolecule/issues/333
+    "import/no-duplicates": ["error", { "prefer-inline": false }],
     "import/no-extraneous-dependencies": [
       "error",
       {

--- a/packages/eslint-config/rules/reactRouterExceptions.ts
+++ b/packages/eslint-config/rules/reactRouterExceptions.ts
@@ -1,4 +1,4 @@
-import { type Linter } from "eslint";
+import type { Linter } from "eslint";
 
 export const reactRouterExceptions = {
   files: ["**/root.tsx", "**/*.route.tsx"],

--- a/packages/eslint-config/rules/storybook.ts
+++ b/packages/eslint-config/rules/storybook.ts
@@ -1,4 +1,4 @@
-import { type Linter } from "eslint";
+import type { Linter } from "eslint";
 import tseslint from "typescript-eslint";
 
 export const storybook: Linter.Config = {

--- a/packages/eslint-config/rules/testFiles.ts
+++ b/packages/eslint-config/rules/testFiles.ts
@@ -1,4 +1,4 @@
-import { type Linter } from "eslint";
+import type { Linter } from "eslint";
 
 export const testFiles = {
   files: [

--- a/packages/eslint-config/rules/typescriptOverrides.ts
+++ b/packages/eslint-config/rules/typescriptOverrides.ts
@@ -1,4 +1,4 @@
-import { type Linter } from "eslint";
+import type { Linter } from "eslint";
 
 export const typescriptOverrides = {
   files: ["**/*.{ts,tsx}"],


### PR DESCRIPTION
## Summary

Switches the default type import style from inline (`import { type Foo }`) to top-level (`import type { Foo }`) to fix React Router 7 compatibility issues with virtual type modules.

## Changes

### ESLint Rules Updated

- ✅ **Disabled** `canonical/prefer-inline-type-import`
- ✅ **Changed** `import/consistent-type-specifier-style` to `"prefer-top-level"`
- ✅ **Updated** `import/no-duplicates` with `{ "prefer-inline": false }`

### Before (v5.x - Inline Style)

```typescript
import { useState, type FC } from "react";
```

### After (v6.0.0 - Top-Level Style)

```typescript
import type { FC } from "react";
import { useState } from "react";
```

## Why This Change?

React Router 7 generates virtual type modules (e.g., `./+types/route`) that **fail to resolve** with inline type imports during production builds. This change:

1. ✅ **Fixes React Router 7 compatibility** - Top-level imports work with virtual modules
2. ✅ **Maintains duplicate detection** - `import/no-duplicates` still warns about multiple imports
3. ✅ **No auto-fix conflicts** - `lint:fix` won't break React Router imports anymore
4. ✅ **Future-proof** - Aligns with TypeScript's `verbatimModuleSyntax` recommendation

## Migration Guide

Most projects can auto-fix imports:

```bash
pnpm update @robeasthope/eslint-config@6.0.0
pnpm lint:fix
```

Mixed imports need manual splitting:

```typescript
// Before
import { useState, type FC, type ReactNode } from "react";

// After - Split manually
import type { FC, ReactNode } from "react";
import { useState } from "react";
```

**Projects using React Router 7** can remove their ESLint rule overrides as these are now built-in.

## Affected Projects

This PR directly addresses:

- **Waterleaf** monorepo - Issue #91
- **Hecate** monorepo - Issue #302
- Any project using React Router 7 with virtual type modules

## Test Plan

- ✅ Updated all package rule files to use top-level imports
- ✅ Verified `lint:fix` converts inline to top-level correctly
- ✅ Confirmed `import/no-duplicates` still detects duplicates (warnings only)
- ✅ Package builds and lints cleanly
- ✅ Created comprehensive changeset for v6.0.0

## Breaking Changes

⚠️ **This is a MAJOR version bump (v6.0.0)**

- Projects using inline type imports will see lint errors
- `lint:fix` will convert inline imports to top-level
- Separate import statements for types and values are now standard

## References

- Fixes #333
- Related: Waterleaf #91, Hecate #302
- React Router Issue: https://github.com/remix-run/react-router/issues/12503
- TypeScript `verbatimModuleSyntax`: https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)