### PR TITLE
fix(markdownlint-config): disable MD040 rule

### DIFF
--- a/.changeset/disable-md040-rule.md
+++ b/.changeset/disable-md040-rule.md
@@ -1,0 +1,7 @@
+---
+"@robeasthope/markdownlint-config": patch
+---
+
+Disable MD040 rule (fenced code language requirement)
+
+The MD040 rule has been causing unnecessary friction by requiring all fenced code blocks to have a language identifier. This change provides more flexibility for markdown authoring while maintaining other code quality standards.

--- a/packages/markdownlint-config/.markdownlint.json
+++ b/packages/markdownlint-config/.markdownlint.json
@@ -9,7 +9,7 @@
   "MD033": false,
   "MD034": false,
   "MD036": false,
-  "MD040": true,
+  "MD040": false,
   "MD041": false,
   "MD051": false
 }


### PR DESCRIPTION
## Summary

Disables the MD040 rule in the markdownlint configuration package. This rule requires all fenced code blocks to have a language identifier, which has been causing unnecessary friction.

## Changes

- **Configuration:** Updated `.markdownlint.json` to set `MD040: false`
- **Changeset:** Created patch changeset for `@robeasthope/markdownlint-config`

## Rationale

The MD040 rule enforces language identifiers on fenced code blocks for syntax highlighting. While helpful in some contexts, it can be overly strict for:
- Generic text output examples
- Console output snippets
- Plain text blocks
- Temporary code snippets

Disabling this rule provides more flexibility in markdown authoring while maintaining other markdown quality standards.

## Related Issues

Created upgrade tracking issues in downstream repositories:
- Hecate: https://github.com/RobEasthope/hecate/issues/472
- Waterleaf: https://github.com/RobEasthope/waterleaf/issues/209
- Tempest: https://github.com/RobEasthope/tempest/issues/17

## Test Plan

- [x] Changeset created for version tracking
- [x] Configuration file updated
- [x] Pre-commit hooks passed (Prettier, markdownlint)
- [x] Pre-push hooks validated changeset requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)