### PR TITLE
feat(eslint-config): add ESLint rule exceptions for Sanity structure files

### DIFF
--- a/.changeset/sanity-structure-exceptions.md
+++ b/.changeset/sanity-structure-exceptions.md
@@ -1,0 +1,23 @@
+---
+"@robeasthope/eslint-config": minor
+---
+
+Add ESLint rule exceptions for Sanity structure files
+
+Sanity Studio structure files (`structure.ts`, `deskStructure.ts`) use specific conventions that conflict with standard ESLint rules:
+
+- **`func-style`**: Arrow functions assigned to constants are the standard Sanity pattern
+- **`id-length`**: The single-letter `S` parameter is a standard Sanity convention for the StructureBuilder
+
+Both rules are now disabled for these files to support the standard Sanity patterns:
+
+```typescript
+export const structure: StructureResolver = (S) =>
+  S.list()
+    .title("Content")
+    .items([...]);
+```
+
+Also renamed `sanitySchema.ts` to `sanity.ts` to better reflect that the file now contains multiple Sanity-related ESLint configurations.
+
+Closes #365

--- a/packages/eslint-config/index.ts
+++ b/packages/eslint-config/index.ts
@@ -7,7 +7,7 @@ import { ignoredFileAndFolders } from "./rules/ignoredFileAndFolders";
 import { packageJson } from "./rules/packageJson";
 import { preferences } from "./rules/preferences";
 import { reactRouterExceptions } from "./rules/reactRouterExceptions";
-import { sanitySchema } from "./rules/sanitySchema";
+import { sanity } from "./rules/sanity";
 import { storybook } from "./rules/storybook";
 import { testFiles } from "./rules/testFiles";
 import { typescriptOverrides } from "./rules/typescriptOverrides";
@@ -38,9 +38,10 @@ const config: any[] = [
   // See: https://github.com/RobEasthope/protomolecule/issues/323
   reactRouterExceptions,
   frameworkRouting,
-  // Sanity schema property ordering for *.schema.ts files
-  // See: https://github.com/RobEasthope/protomolecule/issues/360
-  sanitySchema,
+  // Sanity-specific ESLint configurations:
+  // - Schema property ordering for *.schema.ts files (#360)
+  // - Structure file exceptions for structure.ts and deskStructure.ts (#365)
+  ...sanity,
 ];
 
 export default config;

--- a/packages/eslint-config/rules/sanity.ts
+++ b/packages/eslint-config/rules/sanity.ts
@@ -18,7 +18,7 @@ import type { Linter } from "eslint";
  * @see https://perfectionist.dev/rules/sort-objects
  * @see https://www.sanity.io/docs/schema-field-types
  */
-export const sanitySchema = {
+const sanitySchemaPropertyOrdering = {
   files: ["**/*.schema.ts"],
   rules: {
     "perfectionist/sort-objects": [
@@ -103,3 +103,35 @@ export const sanitySchema = {
     ],
   },
 } satisfies Linter.Config;
+
+/**
+ * ESLint configuration for Sanity Studio structure files
+ *
+ * Sanity structure files (structure.ts, deskStructure.ts) use specific conventions
+ * that conflict with standard ESLint rules:
+ *
+ * 1. Arrow functions assigned to constants (standard Sanity pattern):
+ *    export const structure: StructureResolver = (S) => S.list()...
+ *
+ * 2. Single-letter `S` parameter (Sanity StructureBuilder convention):
+ *    The `S` parameter is universally used in Sanity documentation
+ *    and examples to represent the StructureBuilder object.
+ * @see https://github.com/RobEasthope/protomolecule/issues/365
+ * @see https://www.sanity.io/docs/structure-builder-introduction
+ */
+const sanityStructure = {
+  files: ["**/structure.ts", "**/deskStructure.ts"],
+  rules: {
+    "func-style": "off",
+    "id-length": "off",
+  },
+} satisfies Linter.Config;
+
+/**
+ * Combined Sanity ESLint configurations
+ *
+ * Exports an array containing all Sanity-related ESLint configs:
+ * - Schema property ordering for *.schema.ts files
+ * - Structure file exceptions for structure.ts and deskStructure.ts
+ */
+export const sanity = [sanitySchemaPropertyOrdering, sanityStructure];


### PR DESCRIPTION
## Summary

- Add `func-style` and `id-length` rule exceptions for Sanity structure files (`structure.ts`, `deskStructure.ts`)
- Rename `sanitySchema.ts` → `sanity.ts` to reflect expanded scope
- Export sanity rules as array to support multiple config objects

## Problem

Sanity Studio structure files use specific conventions that conflict with standard ESLint rules:

1. **`func-style`** - Arrow functions assigned to constants are the standard Sanity pattern
2. **`id-length`** - The single-letter `S` parameter is a standard Sanity convention for the StructureBuilder

```typescript
// Standard Sanity pattern that was flagged by ESLint
export const structure: StructureResolver = (S) =>
  S.list()
    .title("Content")
    .items([...]);
```

## Solution

Both rules are now disabled for `**/structure.ts` and `**/deskStructure.ts` files.

## Test plan

- [x] Build passes (`pnpm --filter @robeasthope/eslint-config build`)
- [x] Lint passes (`pnpm --filter @robeasthope/eslint-config lint`)
- [ ] Verify in Tempest monorepo that structure files no longer trigger ESLint errors

Closes #365